### PR TITLE
Optimize pipeline data handling

### DIFF
--- a/fragmenter.cpp
+++ b/fragmenter.cpp
@@ -13,20 +13,23 @@ std::vector<Fragment> Fragmenter::split(uint32_t msg_id, const uint8_t* data, si
   size_t offset = 0;
   for (uint16_t i=0; i<frag_cnt; ++i) {
     size_t chunk = std::min<size_t>(payload_max, len - offset);
-    Fragment f{};
-    f.payload.assign(data + offset, data + offset + chunk);
+
+    std::vector<uint8_t> payload(data + offset, data + offset + chunk);
     offset += chunk;
-    f.hdr.ver = cfg::PIPE_VERSION;
-    f.hdr.flags = 0;
-    if (ack_required) f.hdr.flags |= F_ACK_REQ;
-    if (frag_cnt > 1) f.hdr.flags |= F_FRAG;
-    if (i == frag_cnt-1) f.hdr.flags |= F_LAST;
-    f.hdr.msg_id = msg_id;
-    f.hdr.frag_idx = i;
-    f.hdr.frag_cnt = frag_cnt;
-    f.hdr.payload_len = (uint16_t)chunk;
-    f.hdr.crc16 = 0;
-    out.push_back(std::move(f));
+
+    FrameHeader hdr{};
+    hdr.ver = cfg::PIPE_VERSION;
+    hdr.flags = 0;
+    if (ack_required) hdr.flags |= F_ACK_REQ;
+    if (frag_cnt > 1) hdr.flags |= F_FRAG;
+    if (i == frag_cnt-1) hdr.flags |= F_LAST;
+    hdr.msg_id = msg_id;
+    hdr.frag_idx = i;
+    hdr.frag_cnt = frag_cnt;
+    hdr.payload_len = (uint16_t)chunk;
+    hdr.crc16 = 0;
+
+    out.emplace_back(Fragment{hdr, std::move(payload)});
   }
   return out;
 }

--- a/message_buffer.h
+++ b/message_buffer.h
@@ -1,7 +1,8 @@
 #pragma once
 #include <vector>
-#include <deque>
+#include <list>
 #include <stdint.h>
+#include <unordered_map>
 
 enum class Qos : uint8_t { High=0, Normal=1, Low=2 };
 enum class QosMode : uint8_t { Strict=0, Weighted421=1 };
@@ -43,10 +44,13 @@ public:
 private:
   bool     pick(OutgoingMessage& out);
 
-  std::deque<OutgoingMessage> qH_, qN_, qL_;
+  std::list<OutgoingMessage> qH_, qN_, qL_;
   uint32_t next_id_;
   size_t   total_bytes_;
   size_t   bytesH_ = 0, bytesN_ = 0, bytesL_ = 0;
+
+  struct MsgRef { Qos qos; std::list<OutgoingMessage>::iterator it; };
+  std::unordered_map<uint32_t, MsgRef> index_;
 
   QosMode  mode_ = QosMode::Strict;
   uint8_t  rr_idx_ = 0;   // для Weighted421

--- a/rx_pipeline.h
+++ b/rx_pipeline.h
@@ -4,6 +4,7 @@
 #include <functional>
 #include <map>
 #include <deque>
+#include <unordered_set>
 #include <Arduino.h>
 #include "encryptor.h"
 #include "frame.h"
@@ -37,6 +38,7 @@ private:
   AckCb ack_cb_ = nullptr;
   std::map<uint32_t, AsmState> assemblers_;
   std::deque<uint32_t> dup_window_;
+  std::unordered_set<uint32_t> dup_set_;
   size_t reasm_bytes_ = 0;
 };
 


### PR DESCRIPTION
## Summary
- Reduce allocations in `TxPipeline` by reusing buffers when sending message fragments.
- Speed up RX duplicate checks with a hash-based window and cleaner assembler garbage collection.
- Track message positions for O(1) acknowledgements and streamline fragment construction.

## Testing
- `g++ -std=c++17 -I. -Itest_stubs tx_pipeline.cpp rx_pipeline.cpp fragmenter.cpp message_buffer.cpp frame_log.cpp test_stubs/Arduino.cpp test_stubs/radio_adapter_stub.cpp -c`


------
https://chatgpt.com/codex/tasks/task_e_68a0d03849c48330aa0c1326ae221d71