### PR TITLE
Add startup self-test with chat output

### DIFF
--- a/ESP32_LoRa_Pipeline.ino
+++ b/ESP32_LoRa_Pipeline.ino
@@ -183,6 +183,7 @@ void handleSimple();
 void handleLarge();
 void handleEncTest();
 void handleEncTestBad();
+void handleSelfTest();
 void handleSetMsgId();
 // Append a line to the chat buffer with automatic size limiting
 void chatLine(const String& s);
@@ -219,6 +220,23 @@ void sendKeyRequest();
 void sendKeyResponse();
 
 // End of forward declarations
+
+class SerialChatPrint : public Print {
+  Print& serial;
+  String line;
+public:
+  explicit SerialChatPrint(Print& s) : serial(s) {}
+  size_t write(uint8_t c) override {
+    serial.write(c);
+    if (c == '\n') {
+      chatLine(line);
+      line = "";
+    } else if (c != '\r') {
+      line += (char)c;
+    }
+    return 1;
+  }
+};
 
 static inline void persistMsgId() {
   prefs.begin("lora", false);
@@ -1460,6 +1478,13 @@ void handleEncTestBad() {
   EncSelfTest_badKid(g_ccm, Serial);
   server.send(200, "text/plain", "enctestbad started");
   serialBuffer += String("*SYS:* ENCTESTBAD started\n");
+}
+
+void handleSelfTest() {
+  SerialChatPrint out(Serial);
+  SelfTest_runAll(g_ccm, out);
+  server.send(200, "text/plain", "selftest started");
+  serialBuffer += String("*SYS:* SELFTEST started\n");
 }
 
 void handleSetMsgId() {
@@ -2791,6 +2816,7 @@ void setup() {
   server.on("/large", handleLarge);
   server.on("/enctest", handleEncTest);
   server.on("/enctestbad", handleEncTestBad);
+  server.on("/selftest", handleSelfTest);
   server.on("/msgid", handleSetMsgId);
   // QoS endpoints
   server.on("/sendq", handleSendQ);
@@ -2806,6 +2832,9 @@ void setup() {
   // Authenticated ECDH key exchange endpoint
   server.on("/keydh", handleKeyDh);
   server.begin();
+
+  // Run self-test at startup, outputting results to the serial console.
+  SelfTest_runAll(g_ccm, Serial);
 
   g_rx.setMessageCallback([](uint32_t id, const uint8_t* d, size_t n) {
     Serial.printf("[RX msg %u] %u bytes\n", id, (unsigned)n);

--- a/selftest.cpp
+++ b/selftest.cpp
@@ -56,3 +56,9 @@ void EncSelfTest_badKid(CcmEncryptor& ccm, Print& out) {
   bool ok = ccm.decrypt(enc.data(), enc.size(), aad.data(), aad.size(), dec);
   out.printf("ENCTESTBAD wrong-KID dec=%s (expected FAIL)\n", ok? "OK":"FAIL");
 }
+
+void SelfTest_runAll(CcmEncryptor& ccm, Print& out) {
+  out.println(F("SELFTEST: begin"));
+  EncSelfTest_battery(ccm, out);
+  out.println(F("SELFTEST: end"));
+}

--- a/selftest.h
+++ b/selftest.h
@@ -8,3 +8,4 @@
 bool EncSelfTest_run(CcmEncryptor& ccm, size_t size, Print& out);
 void EncSelfTest_battery(CcmEncryptor& ccm, Print& out);
 void EncSelfTest_badKid(CcmEncryptor& ccm, Print& out);
+void SelfTest_runAll(CcmEncryptor& ccm, Print& out);


### PR DESCRIPTION
## Summary
- add comprehensive `SelfTest_runAll` and dual Serial/chat printer
- expose `/selftest` HTTP endpoint to trigger tests and log to chat
- run self-test automatically at boot with serial output

## Testing
- `g++ -std=c++17 -c selftest.cpp -I.` *(fails: Arduino.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a0db27207483309bdca1a81090ef5c