### PR TITLE
Align radio initialization with reference style

### DIFF
--- a/ESP32_LoRa_Pipeline.ino
+++ b/ESP32_LoRa_Pipeline.ino
@@ -2093,18 +2093,12 @@ void setup() {
   pinMode(PIN_TCXO_DETECT, INPUT_PULLUP);
   float tcxo = (digitalRead(PIN_TCXO_DETECT) == LOW) ? 2.4f : 0.0f;
 
-  int16_t st = radio.begin(433.0, 125.0, 9, 5, 0x12, g_txp, 10, tcxo, false);
+  int16_t st = radio.begin(g_freq_rx_mhz, g_bw_khz, g_sf, g_cr, 0x18, g_txp, 10, tcxo, false);
   if (st != RADIOLIB_ERR_NONE) {
     Serial.printf("Radio begin failed: %d\n", st);
   } else {
     Serial.println(F("Radio OK"));
   }
-
-  applyPreset();
-  Radio_setBandwidth((uint32_t)g_bw_khz);
-  Radio_setSpreadingFactor(g_sf);
-  Radio_setCodingRate(g_cr);
-  Radio_setTxPower(g_txp);
   g_tx.setRetry(g_retryN, g_retryMS);
   g_tx.enableAck(g_ack_on);
   g_ccm.setEnabled(g_enc_on);


### PR DESCRIPTION
## Summary
- initialize SX1262 with preset frequency, bandwidth, spreading factor and coding rate just like the reference implementation
- drop post-init parameter setters and use LoRa sync word 0x18

## Testing
- `g++ -x c++ -std=c++17 -I. -Itest_stubs -fsyntax-only ESP32_LoRa_Pipeline.ino` *(fails: Preferences.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a0da830cc483309667cd6ee6847dec