### PR TITLE
Не удалять сообщение из буфера при исчерпании попыток

### DIFF
--- a/tx_pipeline.cpp
+++ b/tx_pipeline.cpp
@@ -86,7 +86,10 @@ void TxPipeline::loop() {
           waiting_ack_ = false;
         }
       } else {
-        metrics_.ack_fail++; buf_.popFront(); waiting_ack_ = false; waiting_id_ = 0;
+        // сообщение не удаляем, оставляем в буфере при исчерпании попыток
+        metrics_.ack_fail++;
+        waiting_ack_ = false;
+        waiting_id_ = 0;
       }
     }
     return;


### PR DESCRIPTION
## Summary
- Сохранять сообщение в буфере, если исчерпаны повторы отправки

## Testing
- `g++ -std=c++17 -Wall -Werror -I. -c tx_pipeline.cpp` *(ошибка: отсутствует Arduino.h)*

------
https://chatgpt.com/codex/tasks/task_e_68a0df883fb88330b5725f452d14abad