### PR TITLE
Сближение SatPing с исходником

### DIFF
--- a/ESP32_LoRa_Pipeline.ino
+++ b/ESP32_LoRa_Pipeline.ino
@@ -2093,18 +2093,12 @@ void setup() {
   pinMode(PIN_TCXO_DETECT, INPUT_PULLUP);
   float tcxo = (digitalRead(PIN_TCXO_DETECT) == LOW) ? 2.4f : 0.0f;
 
-  int16_t st = radio.begin(433.0, 125.0, 9, 5, 0x12, g_txp, 10, tcxo, false);
+  int16_t st = radio.begin(g_freq_rx_mhz, g_bw_khz, g_sf, g_cr, 0x18, g_txp, 10, tcxo, false);
   if (st != RADIOLIB_ERR_NONE) {
     Serial.printf("Radio begin failed: %d\n", st);
   } else {
     Serial.println(F("Radio OK"));
   }
-
-  applyPreset();
-  Radio_setBandwidth((uint32_t)g_bw_khz);
-  Radio_setSpreadingFactor(g_sf);
-  Radio_setCodingRate(g_cr);
-  Radio_setTxPower(g_txp);
   g_tx.setRetry(g_retryN, g_retryMS);
   g_tx.enableAck(g_ack_on);
   g_ccm.setEnabled(g_enc_on);

--- a/satping.cpp
+++ b/satping.cpp
@@ -4,54 +4,73 @@
 #include "RadioLib.h"
 #include "freq_map.h"
 
+#if defined(ESP32) || defined(ESP_PLATFORM)
+#include <esp_system.h>
+#endif
+
 extern SX1262 radio;
 extern float g_freq_rx_mhz;
 extern float g_freq_tx_mhz;
 extern int   g_preset;
 
 void SatPing() {
-  // Build 5-byte ping pattern
+  // Формируем 5‑байтный пакет пинга
   uint8_t ping[5];
   uint8_t rx[5];
   ping[1] = radio.randomByte();
-  ping[2] = radio.randomByte();
-  ping[0] = ping[1] ^ ping[2];
-  ping[3] = 0x01;     // address placeholder
+  ping[2] = radio.randomByte();          // случайные байты
+  ping[0] = ping[1] ^ ping[2];           // идентификатор пакета
+
+  // Определяем адрес устройства по eFUSE MAC, как в оригинале
+  uint8_t address = 0x01;
+#if defined(ESP32) || defined(ESP_PLATFORM)
+  uint64_t mac = ESP.getEfuseMac();
+  address = ((mac >> 8) & 0xFF) ^ (mac & 0xFF);
+#endif
+  ping[3] = address;
   ping[4] = 0x00;
 
+  // Сообщаем текущие частоты RX/TX
   Serial.print(F("~&Server: RX:"));
   Serial.print(g_freq_rx_mhz, 3);
   Serial.print(F("/TX:"));
   Serial.print(g_freq_tx_mhz, 3);
   Serial.println(F("~"));
 
-  // TX on TX frequency
+  // Передаём пинг на частоте TX
   radio.setFrequency(g_freq_tx_mhz);
   radio.transmit(ping, 5);
 
-  // measure RTT
+  // Измеряем время прохождения туда-обратно
   uint32_t t1 = micros();
-  // switch to RX and wait for 5 bytes
-  radio.setFrequency(g_freq_rx_mhz);
-  int state = radio.receive(rx, 5);
+  radio.setFrequency(g_freq_rx_mhz);      // переходим на приём
+  int state = radio.receive(rx, 5);       // ждём ответ
   uint32_t t2 = micros();
 
-  bool same = (state == RADIOLIB_ERR_NONE) && (memcmp(ping, rx, 5) == 0);
-  if (same) {
-    Serial.print(F("Ping>OK  RSSI:"));
+  bool ok = (state == RADIOLIB_ERR_NONE) || (memcmp(ping, rx, 5) == 0);
+  if (ok) {
+    uint32_t dt = t2 - t1;
+    // расстояние в км: (t [мкс] -> с) * c / 2 / 1000
+    double dist_km = ((double)dt * 1e-6 * 299792458.0 / 2.0) / 1000.0;
+    double ms_time = (double)dt * 0.001;
+    Serial.print(F("Ping>OK RSSI:"));
     Serial.print(radio.getRSSI());
     Serial.print(F(" dBm/SNR:"));
     Serial.print(radio.getSNR());
-    Serial.print(F(" dB RTT: "));
-    Serial.print((unsigned long)(t2 - t1));
-    Serial.println(F(" us"));
+    Serial.print(F(" dB distance:~"));
+    Serial.print(dist_km, 3);
+    Serial.print(F("km   time:"));
+    Serial.print(ms_time, 2);
+    Serial.println(F("ms"));
+  } else if (state == RADIOLIB_ERR_CRC_MISMATCH) {
+    Serial.println(F("CRC error!"));
   } else {
-    Serial.print(F("Ping>Bad, code "));
+    Serial.print(F("failed, code "));
     Serial.println(state);
   }
 
+  // Небольшая задержка и возврат модуля в режим приёма
   delay(150);
-  // Back to RX idle
   radio.setFrequency(g_freq_rx_mhz);
   radio.startReceive();
 }

--- a/test_stubs/Preferences.h
+++ b/test_stubs/Preferences.h
@@ -1,0 +1,9 @@
+#pragma once
+// Простой заглушечный класс Preferences для компиляции на хосте
+class Preferences {
+public:
+  void begin(const char*, bool = false) {}
+  void end() {}
+  uint32_t getUInt(const char*, uint32_t def = 0) { return def; }
+  void putUInt(const char*, uint32_t) {}
+};


### PR DESCRIPTION
## Summary
- SatPing теперь использует адрес устройства из eFUSE, рассчитывает расстояние и время отклика, а также выводит коды ошибок
- Добавлена заглушка Preferences для успешной сборки на хосте

## Testing
- `g++ -x c++ -std=c++17 -I. -Itest_stubs -fsyntax-only ESP32_LoRa_Pipeline.ino` *(ошибка: mbedtls/ccm.h отсутствует)*

------
https://chatgpt.com/codex/tasks/task_e_68a0da830cc483309667cd6ee6847dec