### PR TITLE
Тест: имитация задержки ACK в compat_ack_test

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,13 @@ ENCTESTBAD wrong-KID dec=FAIL (expected FAIL)
 ## Тестирование
 Подробное руководство по ручной проверке веб‑интерфейса и радиомодуля описано в [TESTS.md](TESTS.md).
 Базовые самотесты шифрования выполняются командами `ENCTEST` и `ENCTEST_BAD`; полный сценарий приведён в `TESTS.md`.
+Дополнительно доступен автономный тест совместимости `compat_ack_test`,
+который проверяет согласованность формата пакетов и обмен ACK,
+откладывая передачу подтверждений для имитации задержки радиоканала.
+Компиляция:
+```
+g++ -std=c++17 compat_ack_test.cpp message_buffer.cpp fragmenter.cpp \
+    tx_pipeline.cpp rx_pipeline.cpp frame_log.cpp test_stubs/Arduino.cpp \
+    -I. -Itest_stubs -o compat_ack_test
+./compat_ack_test
+```

--- a/compat_ack_test.cpp
+++ b/compat_ack_test.cpp
@@ -1,0 +1,111 @@
+#include "Arduino.h"
+#include "tx_pipeline.h"
+#include "rx_pipeline.h"
+#include "fragmenter.h"
+#include "message_buffer.h"
+#include "encryptor.h"
+#include "frame.h"
+#include <vector>
+#include <cstring>
+
+// Автономный тест совместимости TX/RX и обмена ACK.
+// Компиляция: g++ -std=c++17 compat_ack_test.cpp message_buffer.cpp fragmenter.cpp \
+//             tx_pipeline.cpp rx_pipeline.cpp frame_log.cpp test_stubs/Arduino.cpp \
+//             -I. -Itest_stubs -o compat_ack_test
+// Запуск:     ./compat_ack_test
+
+// Глобальные указатели для маршрутизации кадров
+static TxPipeline* g_tx = nullptr;
+static RxPipeline* g_rx_local = nullptr;   // Приём ACK
+static RxPipeline* g_rx_remote = nullptr;  // Приём обычных пакетов
+
+// Структура для отложенной доставки ACK
+struct PendingAck {
+  std::vector<uint8_t> frame; // Сырые данные кадра ACK
+  int cycles;                 // Через сколько циклов доставить
+};
+static std::vector<PendingAck> g_pending_ack; // Очередь ожидающих ACK
+
+// Заглушки радио
+bool Radio_sendRaw(const uint8_t* data, size_t len) {
+  if (!data || len < sizeof(FrameHeader)) return true;
+  FrameHeader hdr;
+  memcpy(&hdr, data, sizeof(FrameHeader));
+  if (hdr.flags & F_ACK) {
+    // Сохраняем ACK и доставляем после небольшой задержки,
+    // имитируя передачу по радиоканалу
+    PendingAck pa;
+    pa.frame.assign(data, data + len);
+    pa.cycles = 2; // задержка в два цикла
+    g_pending_ack.push_back(std::move(pa));
+  } else {
+    if (g_rx_remote) g_rx_remote->onReceive(data, len);
+  }
+  return true;
+}
+
+bool Radio_setBandwidth(uint32_t) { return true; }
+bool Radio_setSpreadingFactor(uint8_t) { return true; }
+bool Radio_setCodingRate(uint8_t) { return true; }
+bool Radio_setTxPower(int8_t) { return true; }
+void Radio_forceRx() {}
+bool Radio_setFrequency(uint32_t) { return true; }
+void Radio_onReceive(const uint8_t*, size_t) {}
+
+static void processPendingAck() {
+  if (!g_rx_local) return;
+  for (auto it = g_pending_ack.begin(); it != g_pending_ack.end();) {
+    if (--(it->cycles) <= 0) {
+      g_rx_local->onReceive(it->frame.data(), it->frame.size());
+      it = g_pending_ack.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+int main() {
+  // Подготовка конвейеров
+  PipelineMetrics m_local{}, m_remote{};
+  MessageBuffer buf_local;
+  Fragmenter frag_local;
+  NoEncryptor enc_local, enc_remote;
+  TxPipeline tx(buf_local, frag_local, enc_local, m_local);
+  RxPipeline rx_local(enc_local, m_local);    // принимает ACK
+  RxPipeline rx_remote(enc_remote, m_remote); // принимает сообщение
+  g_tx = &tx; g_rx_local = &rx_local; g_rx_remote = &rx_remote;
+
+  // Буфер для проверки доставки
+  std::vector<uint8_t> received;
+  bool ack_ok = false;
+
+  rx_remote.setMessageCallback([&](uint32_t, const uint8_t* d, size_t n) {
+    received.assign(d, d + n);
+  });
+  rx_local.setAckCallback([&](uint32_t id) {
+    ack_ok = true;
+    tx.notifyAck(id);
+  });
+
+  // Отправляем сообщение с запросом ACK
+  const uint8_t msg[] = {1,2,3,4,5};
+  buf_local.enqueue(msg, sizeof(msg), true);
+
+  // Запускаем цикл, пока сообщение не будет подтверждено
+  for (int i = 0; i < 20 && buf_local.hasPending(); ++i) {
+    tx.loop();
+    processPendingAck();
+    delay(30);
+  }
+
+  // Проверяем доставку и получение ACK
+  bool size_ok = received.size() == sizeof(msg);
+  bool data_ok = size_ok && memcmp(received.data(), msg, sizeof(msg)) == 0;
+  bool ack_seen = m_local.ack_seen == 1;
+  bool ok = size_ok && data_ok && ack_ok && ack_seen;
+
+  Serial.printf("size_ok=%d data_ok=%d ack_ok=%d ack_seen=%d\n",
+                size_ok, data_ok, ack_ok, ack_seen);
+  Serial.println(ok ? "TEST OK" : "TEST FAIL");
+  return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- имитируем задержку доставки ACK в совместимостном тесте
- README: описан тест с задержкой подтверждений

## Testing
- `g++ -std=c++17 compat_ack_test.cpp message_buffer.cpp fragmenter.cpp tx_pipeline.cpp rx_pipeline.cpp frame_log.cpp test_stubs/Arduino.cpp -I. -Itest_stubs -o compat_ack_test && ./compat_ack_test`


------
https://chatgpt.com/codex/tasks/task_e_68a0e2e3b190833089901950950e9c90