### PR TITLE
Добавлен watchdog для Radxa Zero

### DIFF
--- a/ESP32_LoRa_Pipeline.ino
+++ b/ESP32_LoRa_Pipeline.ino
@@ -2084,6 +2084,17 @@ static void pollUart(Stream& s, String& line) {
   }
 }
 
+// Watchdog заглушка для Radxa Zero по второму UART
+static void radxaWatchdog() {
+  // Отправляем периодический ping, чтобы контролировать связь
+  static uint32_t lastPing = 0;
+  uint32_t now = millis();
+  if (now - lastPing >= 1000) {
+    SerialRadxa.println("[WDOG] ping");
+    lastPing = now;
+  }
+}
+
 void setup() {
   Serial.begin(115200);
   while (!Serial) { delay(10); }
@@ -2257,6 +2268,7 @@ void setup() {
 void loop() {
   pollUart(Serial, g_line);
   pollUart(SerialRadxa, g_line_radxa);
+  radxaWatchdog();
   // Handle incoming HTTP clients.
   server.handleClient();
   radioPoll();

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ ENCTEST size=32 enc=OK dec=OK time_enc=...us time_dec=...us
 ENCTESTBAD wrong-KID dec=FAIL (expected FAIL)
 ```
 
+## Watchdog для Radxa Zero
+Добавлена заглушка функции `radxaWatchdog()` для обмена ping-сообщениями с Radxa Zero
+по второму UART. Для отправки таких сообщений на стороне Radxa присутствует скрипт
+`uart_stub/watchdog.py`.
+
 ## Тестирование
 Подробное руководство по ручной проверке веб‑интерфейса и радиомодуля описано в [TESTS.md](TESTS.md).
 Базовые самотесты шифрования выполняются командами `ENCTEST` и `ENCTEST_BAD`; полный сценарий приведён в `TESTS.md`.

--- a/uart_stub/watchdog.py
+++ b/uart_stub/watchdog.py
@@ -1,0 +1,33 @@
+"""Простой watchdog для Radxa Zero.
+
+Отправляет периодические ping-сообщения по второму UART,
+что позволяет микроконтроллеру контролировать наличие хоста.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+from .uart import UARTInterface
+
+
+def watchdog_loop(port: str, baudrate: int, interval: float = 1.0) -> None:
+    """Циклично отправляет ping-сообщения."""
+    uart = UARTInterface(port=port, baudrate=baudrate)
+    while True:
+        uart.send(b"[WDOG] ping\n")
+        time.sleep(interval)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Watchdog для Radxa Zero")
+    parser.add_argument("--port", default="/dev/ttyS2", help="Путь к UART устройству")
+    parser.add_argument("--baudrate", type=int, default=115200, help="Скорость UART")
+    parser.add_argument("--interval", type=float, default=1.0, help="Интервал ping, сек")
+    args = parser.parse_args()
+    watchdog_loop(args.port, args.baudrate, args.interval)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- добавить заглушку `radxaWatchdog` для связи со вторым UART
- реализовать Python-скрипт `watchdog.py` для Radxa Zero
- обновить README c описанием новой функции

## Testing
- `python -m py_compile uart_stub/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0ee3600c48330a9f19ca758c3a015