### PR TITLE
Исключение compat_ack_test из сборки Arduino

### DIFF
--- a/compat_ack_test.cpp
+++ b/compat_ack_test.cpp
@@ -1,3 +1,6 @@
+#ifndef ARDUINO
+// Этот файл запускает совместимый тест ACK на десктопе
+// и исключается при сборке прошивки в Arduino IDE.
 #include "Arduino.h"
 #include "tx_pipeline.h"
 #include "rx_pipeline.h"
@@ -87,3 +90,4 @@ int main() {
   Serial.println(ok ? "TEST OK" : "TEST FAIL");
   return ok ? 0 : 1;
 }
+#endif // !ARDUINO


### PR DESCRIPTION
## Summary
- спрятан файл compat_ack_test.cpp за `#ifndef ARDUINO`, чтобы тест не линковался вместе с прошивкой

## Testing
- `g++ -std=c++20 -I test_stubs compat_ack_test.cpp tx_pipeline.cpp rx_pipeline.cpp fragmenter.cpp message_buffer.cpp frame_log.cpp test_stubs/Arduino.cpp -o compat_ack_test`
- `./compat_ack_test`


------
https://chatgpt.com/codex/tasks/task_e_68a14bf6a65c83309d039f4c2a14030a