### PR TITLE
fix: guard key exchange test compilation

### DIFF
--- a/key_exchange_test.cpp
+++ b/key_exchange_test.cpp
@@ -1,3 +1,6 @@
+// Этот файл компилируется только при запуске теста обмена ключами
+#ifdef KEY_EXCHANGE_TEST
+
 #include "Arduino.h"
 #include "encryptor_ccm.h"
 #include "selftest.h"
@@ -128,4 +131,6 @@ int main() {
   EncSelfTest_run(g_ccm, 32, Serial);
   return 0;
 }
+
+#endif  // KEY_EXCHANGE_TEST
 

--- a/run_key_exchange_test.sh
+++ b/run_key_exchange_test.sh
@@ -2,5 +2,6 @@
 # Скрипт компилирует и запускает тест обмена ключами
 set -e
 
-g++ -std=c++17 -DARDUINO_ARCH_ESP32 key_exchange_test.cpp selftest.cpp test_stubs/Arduino.cpp -I. -Itest_stubs -lmbedtls -lmbedcrypto -lmbedx509 -o key_exchange_test
+# компилируем, определяя макрос KEY_EXCHANGE_TEST
+g++ -std=c++17 -DARDUINO_ARCH_ESP32 -DKEY_EXCHANGE_TEST key_exchange_test.cpp selftest.cpp test_stubs/Arduino.cpp -I. -Itest_stubs -lmbedtls -lmbedcrypto -lmbedx509 -o key_exchange_test
 ./key_exchange_test


### PR DESCRIPTION
## Summary
- guard key_exchange_test.cpp behind KEY_EXCHANGE_TEST macro to prevent duplicate symbols when building the main sketch
- define KEY_EXCHANGE_TEST in test script to enable compilation of test code

## Testing
- `./run_key_exchange_test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a22491ad8c8330a492a9b289bac009