### PR TITLE
Поддержка hex-формата для корневого ключа

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - **Персистентный msg_id в NVS** (исключение повторного нонса)
 - **Анти-replay** (окно и порог старых ID)
 - Модуль `crypto_spec` с функцией `setCurrentKey` для хранения ключа и его CRC-16
+- В том же модуле добавлена `setRootKeyHex`, принимающая корневой ключ в виде hex-строки
 
 ## Используемые библиотеки
 - [Arduino core for ESP32](https://github.com/espressif/arduino-esp32) — базовые классы (`Arduino.h`, `Preferences`, `WiFi`, `WebServer`)

--- a/libs/crypto_spec.cpp
+++ b/libs/crypto_spec.cpp
@@ -1,3 +1,5 @@
+// Реализация методов и данных модуля crypto_spec
+
 #include "crypto_spec.h"
 #include <string.h>
 
@@ -17,14 +19,39 @@ namespace {
     }
     return crc;
   }
+
+  // Преобразование hex-символа в число 0..15
+  static uint8_t hexToNibble(char c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return 0xFF;
+  }
 }
 
 namespace crypto_spec {
-  // Статический корневой ключ, используемый для HMAC в ECDH
-  const uint8_t KEYDH_ROOT_KEY[16] = {
-    0x73, 0xF2, 0xBC, 0x91, 0x0D, 0x4A, 0x52, 0xE6,
-    0x8C, 0x47, 0x3B, 0x19, 0x5D, 0xA8, 0x61, 0x24
-  };
+  // Глобальный корневой ключ, используемый для HMAC в ECDH
+  uint8_t KEYDH_ROOT_KEY[16] = {0};
+
+  // Установка корневого ключа из hex-строки
+  bool setRootKeyHex(const char* hex) {
+    if (!hex) return false;
+    for (int i = 0; i < 16; ++i) {
+      uint8_t hi = hexToNibble(hex[i * 2]);
+      uint8_t lo = hexToNibble(hex[i * 2 + 1]);
+      if (hi == 0xFF || lo == 0xFF) return false;
+      KEYDH_ROOT_KEY[i] = (hi << 4) | lo;
+    }
+    return true;
+  }
+
+  // Значение корневого ключа по умолчанию (hex-строка)
+  static const char DEFAULT_ROOT_KEY[] = "73F2BC910D4A52E68C473B195DA86124";
+
+  // Статический загрузчик, преобразующий строку в массив при старте
+  struct RootKeyLoader {
+    RootKeyLoader() { setRootKeyHex(DEFAULT_ROOT_KEY); }
+  } rootKeyLoader;
 
   uint8_t CURRENT_KEY[16] = {0};
   uint16_t CURRENT_KEY_CRC = 0;

--- a/libs/crypto_spec.h
+++ b/libs/crypto_spec.h
@@ -5,7 +5,12 @@
 // Спецификация статических криптографических параметров
 namespace crypto_spec {
   // Корневой ключ для проверки HMAC при ECDH
-  extern const uint8_t KEYDH_ROOT_KEY[16];
+  // Значение задаётся hex-строкой и преобразуется в массив байтов
+  extern uint8_t KEYDH_ROOT_KEY[16];
+
+  // Установка корневого ключа из 32-символьной hex-строки
+  // Возвращает true при успешном разборе
+  bool setRootKeyHex(const char* hex);
 
   // Текущий AES-ключ и его CRC-16 для быстрого доступа
   extern uint8_t CURRENT_KEY[16];


### PR DESCRIPTION
## Summary
- позволить задавать корневой ключ как 32-символьную hex-строку
- добавить установку корневого ключа и автозагрузку из строки по умолчанию
- задокументировать функцию `setRootKeyHex`

## Testing
- `g++ -std=c++17 freq_map_test.cpp -o freq_map_test && ./freq_map_test`
- `g++ -std=c++17 compat_ack_test.cpp -o compat_ack_test && ./compat_ack_test` *(fail: Arduino.h: No such file or directory)*
- `./run_key_exchange_test.sh` *(fail: mbedtls/ccm.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a296038cb88330bb8e10eadbfa58d2