### PR TITLE
Поддержка корневого ключа из hex-строки

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - Локальные тесты `ENCTEST`, `ENCTEST_BAD`
 - **Персистентный msg_id в NVS** (исключение повторного нонса)
 - **Анти-replay** (окно и порог старых ID)
-- Модуль `crypto_spec` (в корне проекта) с функцией `setCurrentKey` для хранения ключа и его CRC-16
+- Модуль `crypto_spec` (в корне проекта) с функциями `setCurrentKey` для хранения ключа и его CRC-16 и `setRootKeyHex` для установки корневого ключа из 32‑символьной hex-строки (по умолчанию загружается встроенное значение)
 
 ## Используемые библиотеки
 - [Arduino core for ESP32](https://github.com/espressif/arduino-esp32) — базовые классы (`Arduino.h`, `Preferences`, `WiFi`, `WebServer`)

--- a/crypto_spec.cpp
+++ b/crypto_spec.cpp
@@ -1,5 +1,6 @@
 #include "crypto_spec.h"
 #include <string.h>
+#include <stdlib.h>
 
 namespace {
   // Локальная функция для расчёта CRC-16 (CRC-CCITT)
@@ -17,21 +18,36 @@ namespace {
     }
     return crc;
   }
+
+  // Строка по умолчанию для корневого ключа (32 hex-символа)
+  static const char DEFAULT_ROOT_KEY_HEX[] = "73F2BC910D4A52E68C473B195DA86124";
 }
 
 namespace crypto_spec {
-  // Статический корневой ключ, используемый для HMAC в ECDH
-  const uint8_t KEYDH_ROOT_KEY[16] = {
-    0x73, 0xF2, 0xBC, 0x91, 0x0D, 0x4A, 0x52, 0xE6,
-    0x8C, 0x47, 0x3B, 0x19, 0x5D, 0xA8, 0x61, 0x24
-  };
+  // Корневой ключ для HMAC, заполняется из hex-строки
+  uint8_t KEYDH_ROOT_KEY[16] = {0};
 
   uint8_t CURRENT_KEY[16] = {0};
   uint16_t CURRENT_KEY_CRC = 0;
+
+  bool setRootKeyHex(const char* hex) {
+    if (!hex || strlen(hex) != 32) return false;
+    for (int i = 0; i < 16; ++i) {
+      char buf[3] = { hex[i * 2], hex[i * 2 + 1], '\0' };
+      char* end = nullptr;
+      long val = strtol(buf, &end, 16);
+      if (*end != '\0') return false;
+      KEYDH_ROOT_KEY[i] = static_cast<uint8_t>(val);
+    }
+    return true;
+  }
 
   void setCurrentKey(const uint8_t* key) {
     if (!key) return;
     memcpy(CURRENT_KEY, key, 16);
     CURRENT_KEY_CRC = crc16(CURRENT_KEY, 16);
   }
+
+  // Автоматическая загрузка корневого ключа при старте
+  static const bool ROOT_KEY_LOADED = setRootKeyHex(DEFAULT_ROOT_KEY_HEX);
 }

--- a/crypto_spec.h
+++ b/crypto_spec.h
@@ -5,7 +5,8 @@
 // Спецификация статических криптографических параметров
 namespace crypto_spec {
   // Корневой ключ для проверки HMAC при ECDH
-  extern const uint8_t KEYDH_ROOT_KEY[16];
+  // может быть установлен из 32‑символьной hex‑строки
+  extern uint8_t KEYDH_ROOT_KEY[16];
 
   // Текущий AES-ключ и его CRC-16 для быстрого доступа
   extern uint8_t CURRENT_KEY[16];
@@ -13,4 +14,8 @@ namespace crypto_spec {
 
   // Установка нового AES-ключа с автоматическим расчётом CRC-16
   void setCurrentKey(const uint8_t* key);
+
+  // Установка корневого ключа из 32‑символьной hex‑строки
+  // Возвращает true при успешном разборе строки
+  bool setRootKeyHex(const char* hex);
 }


### PR DESCRIPTION
## Summary
- добавить функцию `setRootKeyHex` для установки корневого ключа по 32-символьной hex-строке
- автоматическая загрузка ключа из встроенной hex-строки по умолчанию
- обновлён README с описанием новой функции

## Testing
- `./run_key_exchange_test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a2972aba0083309aca172140ff8776