### PR TITLE
Добавлены EMA-метрики и профили P0–P3

### DIFF
--- a/metrics.h
+++ b/metrics.h
@@ -2,6 +2,21 @@
 #pragma once
 #include <stdint.h>
 
+// Простая экспоненциальная скользящая средняя
+struct EmaCounter {
+  float value = 0.0f;    // текущее значение EMA
+  float alpha = 0.1f;    // коэффициент сглаживания
+  bool initialized = false;
+
+  // обновление счётчика новым измерением
+  inline void update(float sample) {
+    if (initialized)
+      value = alpha * sample + (1.0f - alpha) * value;
+    else
+      { value = sample; initialized = true; }
+  }
+};
+
 struct PipelineMetrics {
   // TX/RX
   uint32_t tx_frames = 0, tx_bytes = 0, tx_msgs = 0;
@@ -25,4 +40,11 @@ struct PipelineMetrics {
   // Канальные параметры
   float last_snr = 0.0f;   // последний измеренный SNR
   float last_ebn0 = 0.0f;  // последний измеренный Eb/N0
+
+  // EMA-метрики качества канала
+  EmaCounter per_ema;      // Packet Error Rate
+  EmaCounter rtt_ema_ms;   // время кругового обхода
+  EmaCounter goodput_ema;  // полезная пропускная способность
+  EmaCounter snr_ema;      // средний SNR
+  EmaCounter ebn0_ema;     // средний Eb/N0
 };

--- a/radio_adapter.h
+++ b/radio_adapter.h
@@ -12,6 +12,9 @@ void Radio_forceRx();
 // Получение качественных метрик канала
 bool Radio_getSNR(float& snr);        // отношение сигнал/шум последнего пакета
 bool Radio_getEbN0(float& ebn0);      // отношение энергии бита к спектральной плотности шума
+// Упрощённые методы получения метрик
+inline float Radio_readSNR()  { float v = 0.0f; Radio_getSNR(v);  return v; }
+inline float Radio_readEbN0() { float v = 0.0f; Radio_getEbN0(v); return v; }
 bool Radio_isSynced();                // есть ли синхронизация по уникальному слову
 
 bool Radio_setFrequency(uint32_t hz);

--- a/tx_pipeline.h
+++ b/tx_pipeline.h
@@ -14,11 +14,13 @@ public:
   bool ackEnabled() const { return ack_enabled_; }
   void notifyAck(uint32_t highest, uint32_t bitmap);
   void setEncEnabled(bool v) { enc_enabled_ = v; }
-  void setFecEnabled(bool v) { fec_enabled_ = v; }
+  void setFecEnabled(bool v) { fec_enabled_ = v; fec_mode_ = v ? 1 : 0; }
   void setInterleaveDepth(uint8_t d) { interleave_depth_ = d; }
 private:
   void sendMessageFragments(const OutgoingMessage& m);
   bool interFrameGap();
+  void updateProfile();       // обновление профиля по метрикам
+  void applyProfile(uint8_t p);
 
   MessageBuffer& buf_;
   Fragmenter& frag_;
@@ -37,5 +39,10 @@ private:
 
   bool enc_enabled_ = cfg::ENCRYPTION_ENABLED_DEFAULT;
   bool fec_enabled_ = cfg::FEC_ENABLED_DEFAULT;
+  uint8_t fec_mode_ = 0;                       // тип FEC: 0-выкл,1-повтор
   uint8_t interleave_depth_ = cfg::INTERLEAVER_DEPTH_DEFAULT;
+
+  uint16_t payload_len_ = cfg::LORA_MTU - FRAME_HEADER_SIZE; // максимальная полезная нагрузка
+  uint8_t repeat_count_ = 1;                  // повторение кадров
+  uint8_t profile_idx_ = 0;                   // текущий профиль P0..P3
 };

--- a/tx_profile_test.cpp
+++ b/tx_profile_test.cpp
@@ -1,0 +1,55 @@
+#ifndef ARDUINO
+#include <cstdio>
+#define private public
+#include "tx_pipeline.h"
+#undef private
+
+class Print; // forward declaration for FrameLog::dump stub
+
+namespace FrameLog {
+void push(char, const uint8_t*, size_t) {}
+void dump(Print&, unsigned int) {}
+}
+namespace tdd {
+void maintain() {}
+bool isTxPhase(unsigned long) { return false; }
+}
+
+class DummyEncryptor : public IEncryptor {
+public:
+  bool encrypt(const uint8_t*, size_t, const uint8_t*, size_t, std::vector<uint8_t>&) override { return false; }
+  bool decrypt(const uint8_t*, size_t, const uint8_t*, size_t, std::vector<uint8_t>&) override { return false; }
+  bool isReady() const override { return false; }
+};
+
+int main() {
+  PipelineMetrics metrics{};
+  MessageBuffer buf;
+  Fragmenter frag;
+  DummyEncryptor enc;
+  TxPipeline tx(buf, frag, enc, metrics);
+
+  metrics.per_ema.value = 0.0f;
+  metrics.ebn0_ema.value = 10.0f;
+  tx.updateProfile();
+  if (tx.profile_idx_ != 0) { std::printf("P0 fail\n"); return 1; }
+
+  metrics.per_ema.value = 0.15f;
+  metrics.ebn0_ema.value = 10.0f;
+  tx.updateProfile();
+  if (tx.profile_idx_ != 1) { std::printf("P1 fail\n"); return 1; }
+
+  metrics.per_ema.value = 0.25f;
+  metrics.ebn0_ema.value = 6.0f;
+  tx.updateProfile();
+  if (tx.profile_idx_ != 2) { std::printf("P2 fail\n"); return 1; }
+
+  metrics.per_ema.value = 0.35f;
+  metrics.ebn0_ema.value = 2.0f;
+  tx.updateProfile();
+  if (tx.profile_idx_ != 3) { std::printf("P3 fail\n"); return 1; }
+
+  std::printf("tx_profile_test OK\n");
+  return 0;
+}
+#endif // ARDUINO


### PR DESCRIPTION
## Summary
- Добавлен универсальный EMA-счётчик и EMA-метрики PER/RTT/goodput/SNR/EbN0
- В `radio_adapter.h` появились функции получения SNR и Eb/N0
- Реализовано переключение профилей P0–P3 в `TxPipeline`
- Документация дополнена описанием профилей и порогов
- Добавлен юнит-тест переключения профилей и упоминание его в README

## Testing
- `./run_key_exchange_test.sh`
- `g++ -std=c++17 -Itest_stubs -c tx_pipeline.cpp`
- `g++ -std=c++17 tx_profile_test.cpp tx_pipeline.cpp message_buffer.cpp fragmenter.cpp test_stubs/Arduino.cpp test_stubs/radio_adapter_stub.cpp -I. -Itest_stubs -o tx_profile_test`
- `./tx_profile_test`


------
https://chatgpt.com/codex/tasks/task_e_68a2f606c09c8330b99f549459fb3e3b