### PR TITLE
fix: исключить тесты из прошивки и подключить FEC реализации

### DIFF
--- a/fec_impl.cpp
+++ b/fec_impl.cpp
@@ -1,0 +1,4 @@
+// Этот файл подключает реализации сложных FEC кодеров,
+// чтобы при сборке прошивки Arduino подтянула исходники из каталога libs.
+#include "libs/rs/rs.cpp"
+#include "libs/viterbi/viterbi.cpp"

--- a/fec_test.cpp
+++ b/fec_test.cpp
@@ -1,3 +1,5 @@
+#ifndef ARDUINO
+// Юнит‑тест простейшего FEC, не участвует в прошивке
 #include "fec.h"
 #include <vector>
 #include <cassert>
@@ -16,3 +18,4 @@ int main() {
   std::cout << "fec_ok\n";
   return 0;
 }
+#endif // !ARDUINO

--- a/frame_header_test.cpp
+++ b/frame_header_test.cpp
@@ -1,3 +1,5 @@
+#ifndef ARDUINO
+// Этот файл содержит юнит‑тест заголовка кадра и не компилируется для прошивки
 #include "frame.h"
 #include <vector>
 #include <iostream>
@@ -35,3 +37,4 @@ int main() {
   std::cout << "frame_header_test ok\n";
   return 0;
 }
+#endif // !ARDUINO

--- a/interleaver_test.cpp
+++ b/interleaver_test.cpp
@@ -1,3 +1,5 @@
+#ifndef ARDUINO
+// Тест чередователя байтов, исключается из сборки прошивки
 #include "interleaver.h"
 #include <vector>
 #include <cassert>
@@ -13,3 +15,4 @@ int main() {
   std::cout << "interleave_ok\n";
   return 0;
 }
+#endif // !ARDUINO


### PR DESCRIPTION
## Summary
- завернули тесты `frame_header`, `fec` и `interleaver` в `#ifndef ARDUINO`
- добавили файл `fec_impl.cpp`, который притягивает реализации RS и Viterbi из каталога libs

## Testing
- `g++ -std=c++17 -I. frame_header_test.cpp -o /tmp/frame_header_test && /tmp/frame_header_test`
- `g++ -std=c++17 -I. fec_test.cpp libs/rs/rs.cpp libs/viterbi/viterbi.cpp -o /tmp/fec_test && /tmp/fec_test`
- `g++ -std=c++17 -I. interleaver_test.cpp -o /tmp/interleaver_test && /tmp/interleaver_test`
- `g++ -std=c++17 -I. -c fec_impl.cpp`

------
https://chatgpt.com/codex/tasks/task_e_68a32583d2b88330b68edd54c275c9e2