### PR TITLE
Реализованы функции получения SNR и расчёта Eb/N0

### DIFF
--- a/ESP32_LoRa_Pipeline.ino
+++ b/ESP32_LoRa_Pipeline.ino
@@ -25,6 +25,7 @@
 
 #include <string.h> // for memcmp
 #include <ctype.h>   // for toupper when parsing hex strings
+#include <math.h>    // для вычисления Eb/N0
 
 // --- WiFi and Web server includes ---
 #include <WiFi.h>
@@ -343,6 +344,20 @@ bool Radio_setTxPower(int8_t dBm) {
 }
 void Radio_forceRx() {
   radio.startReceive();
+}
+
+// Получаем SNR последнего пакета из драйвера
+bool Radio_getSNR(float& snr) {
+  snr = radio.getSNR();
+  return true;
+}
+
+// Расчёт Eb/N0 на основе текущего SNR и параметров модуляции
+bool Radio_getEbN0(float& ebn0) {
+  float snr = radio.getSNR();
+  float efficiency = ((float)g_sf * 4.0f / (float)g_cr) / (1 << g_sf); // бит/Гц
+  ebn0 = snr - 10.0f * log10f(efficiency);
+  return true;
 }
 
 static void radioPoll() {


### PR DESCRIPTION
## Summary
- реализованы `Radio_getSNR` и `Radio_getEbN0` в основном скетче
- добавлен заголовок `<math.h>` для вычисления метрик

## Testing
- `./run_key_exchange_test.sh`
- `g++ -std=c++17 freq_map_test.cpp -o freq_map_test && ./freq_map_test`
- `g++ -std=c++17 tx_profile_test.cpp -o tx_profile_test && ./tx_profile_test` *(ошибка линковки: undefined reference)*
- `g++ -std=c++17 test_web_interface.cpp -o test_web_interface && ./test_web_interface`


------
https://chatgpt.com/codex/tasks/task_e_68a33011aca88330b4debc0294f20b5d