### PR TITLE
Добавлены скользящие окна метрик и адаптивный контроллер

### DIFF
--- a/ESP32_LoRa_Pipeline.ino
+++ b/ESP32_LoRa_Pipeline.ino
@@ -783,10 +783,10 @@ void handleMetrics() {
 // Обработчик /linkdiag: отдаёт короткие метрики канала в JSON
 void handleLinkDiag() {
   String json = "{";
-  json += "\"per\":" + String(g_metrics.per_ema.value, 3);
-  json += ",\"rtt_p50\":" + String(g_metrics.rtt_ema_ms.value, 2);
-  json += ",\"rtt_p95\":" + String(g_metrics.rtt_ema_ms.value, 2);
-  json += ",\"goodput\":" + String(g_metrics.goodput_ema.value, 2);
+  json += "\"per\":" + String(g_metrics.per_window.avg(), 3);
+  json += ",\"rtt_p50\":" + String(g_metrics.rtt_window_ms.avg(), 2);
+  json += ",\"rtt_p95\":" + String(g_metrics.rtt_window_ms.avg(), 2);
+  json += ",\"goodput\":" + String(g_metrics.goodput_window.avg(), 2);
   json += ",\"profile\":\"" + String((int)g_bank) + ":" + String(g_preset) + "\"";
   json += ",\"bitmap\":\"\"";
   json += ",\"tx_frames\":" + String(g_metrics.tx_frames);

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - SR‑ARQ с настраиваемым окном кадров (`setWindowSize`), буфером вне порядка и кумулятивным ACK через `ack_mask`
   - Интервал агрегации ACK настраивается через `setAckAgg`
 - Планировщик слотов TDD (`tdd_scheduler`) с окнами `TX`, `ACK` и защитным интервалом
-- EMA‑метрики PER/RTT/goodput/SNR/EbN0 и автоматические профили `P0–P3`
+- Скользящие окна PER/RTT/goodput/EbN0 и контроллер профилей `P0–P3`
 
 ## Телеметрия канала
 - Вкладка **Link Diagnostics** веб‑интерфейса показывает графики PER, RTT p50/p95 и goodput.
@@ -234,7 +234,7 @@ ENCTESTBAD wrong-KID dec=FAIL (expected FAIL)
 | P2 | PER ≤ 0.3 и Eb/N0 ≥ 3 дБ | 96  | rs_vit | 8  | 3 |
 | P3 | иначе                     | 64  | rs_vit | 16 | 4 |
 
-Для доступа к последним измеренным значениям доступны функции `Radio_getSNR`/`Radio_getEbN0` и их сокращённые версии `Radio_readSNR`/`Radio_readEbN0`.
+Для доступа к последним измеренным значениям доступны функции `Radio_getSNR`/`Radio_getEbN0`/`Radio_getLinkQuality` и их сокращённые версии `Radio_readSNR`/`Radio_readEbN0`/`Radio_readLinkQuality`.
 
 ### TDD расписание
 - Параметры окон `TDD_TX_WINDOW_MS`, `TDD_ACK_WINDOW_MS` и `TDD_GUARD_MS` заданы в `config.h`.

--- a/radio_adapter.h
+++ b/radio_adapter.h
@@ -12,9 +12,11 @@ void Radio_forceRx();
 // Получение качественных метрик канала
 bool Radio_getSNR(float& snr);        // отношение сигнал/шум последнего пакета
 bool Radio_getEbN0(float& ebn0);      // отношение энергии бита к спектральной плотности шума
+bool Radio_getLinkQuality(bool& good); // булев флаг качества канала
 // Упрощённые методы получения метрик
 inline float Radio_readSNR()  { float v = 0.0f; Radio_getSNR(v);  return v; }
 inline float Radio_readEbN0() { float v = 0.0f; Radio_getEbN0(v); return v; }
+inline bool  Radio_readLinkQuality() { bool v = false; Radio_getLinkQuality(v); return v; }
 bool Radio_isSynced();                // есть ли синхронизация по уникальному слову
 
 bool Radio_setFrequency(uint32_t hz);

--- a/tx_pipeline.h
+++ b/tx_pipeline.h
@@ -34,7 +34,7 @@ public:
 private:
   void sendMessageFragments(const OutgoingMessage& m);
   bool interFrameGap();
-  void updateProfile();       // обновление профиля по метрикам
+  void controlProfile();      // контроллер изменения профиля по метрикам
   void applyProfile(uint8_t p);
 
   MessageBuffer& buf_;

--- a/tx_profile_test.cpp
+++ b/tx_profile_test.cpp
@@ -2,6 +2,7 @@
 #include <cstdio>
 #define private public
 #include "tx_pipeline.h"
+#include <ccsds_link.h>
 #undef private
 
 class Print; // заглушка для FrameLog::dump
@@ -20,6 +21,12 @@ void maintain() {}
 bool isTxPhase(unsigned long) { return false; }
 }
 
+// Заглушки модуля CCSDS: кодирование/декодирование не требуются в тесте
+namespace ccsds {
+void encode(const uint8_t*, size_t, uint32_t, const Params&, std::vector<uint8_t>&) {}
+bool decode(const uint8_t*, size_t, uint32_t, const Params&, std::vector<uint8_t>&, int&) { return false; }
+}
+
 class DummyEncryptor : public IEncryptor {
 public:
   bool encrypt(const uint8_t*, size_t, const uint8_t*, size_t, std::vector<uint8_t>&) override { return false; }
@@ -34,24 +41,32 @@ int main() {
   DummyEncryptor enc;
   TxPipeline tx(buf, frag, enc, metrics);
 
-  metrics.per_ema.value = 0.0f;
-  metrics.ebn0_ema.value = 10.0f;
-  tx.updateProfile();
+  metrics.per_window.clear();
+  metrics.ebn0_window.clear();
+  metrics.per_window.add(0.0f);
+  metrics.ebn0_window.add(10.0f);
+  tx.controlProfile();
   if (tx.profile_idx_ != 0) { std::printf("P0 fail\n"); return 1; }
 
-  metrics.per_ema.value = 0.15f;
-  metrics.ebn0_ema.value = 10.0f;
-  tx.updateProfile();
+  metrics.per_window.clear();
+  metrics.ebn0_window.clear();
+  metrics.per_window.add(0.15f);
+  metrics.ebn0_window.add(10.0f);
+  tx.controlProfile();
   if (tx.profile_idx_ != 1) { std::printf("P1 fail\n"); return 1; }
 
-  metrics.per_ema.value = 0.25f;
-  metrics.ebn0_ema.value = 6.0f;
-  tx.updateProfile();
+  metrics.per_window.clear();
+  metrics.ebn0_window.clear();
+  metrics.per_window.add(0.25f);
+  metrics.ebn0_window.add(6.0f);
+  tx.controlProfile();
   if (tx.profile_idx_ != 2) { std::printf("P2 fail\n"); return 1; }
 
-  metrics.per_ema.value = 0.35f;
-  metrics.ebn0_ema.value = 2.0f;
-  tx.updateProfile();
+  metrics.per_window.clear();
+  metrics.ebn0_window.clear();
+  metrics.per_window.add(0.35f);
+  metrics.ebn0_window.add(2.0f);
+  tx.controlProfile();
   if (tx.profile_idx_ != 3) { std::printf("P3 fail\n"); return 1; }
 
   std::printf("tx_profile_test OK\n");


### PR DESCRIPTION
## Summary
- Добавлен флаг качества канала и быстрые методы чтения SNR/EbN0
- Реализованы скользящие окна для PER/RTT/goodput/EbN0
- Контроллер в передающем тракте подстраивает payload, повторы и FEC

## Testing
- `g++ -std=c++17 tx_profile_test.cpp tx_pipeline.cpp fragmenter.cpp message_buffer.cpp -I. -Itest_stubs -Ilibs/ccsds_link -o tx_profile_test && ./tx_profile_test`
- `g++ -std=c++17 freq_map_test.cpp -I. -Itest_stubs -o freq_map_test && ./freq_map_test`
- `./run_key_exchange_test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a4359522588330954a3e006fb014b9