### PR TITLE
Fix FEC header include path for satping

### DIFF
--- a/satping.cpp
+++ b/satping.cpp
@@ -5,7 +5,7 @@
 #include <vector>
 #include "RadioLib.h"
 #include "freq_map.h"
-#include <fec.h>
+#include "libs/ccsds_link/fec.h" // функции помехоустойчивого кодирования
 #include "radio_adapter.h"
 #include "fragmenter.h"   // работа с фрагментами
 #include "satping.h"  // описание структур PingOptions и PingStats


### PR DESCRIPTION
## Summary
- fix include to FEC library via libs/ccsds_link

## Testing
- `g++ -std=c++17 -I libs -I libs/ccsds_link -I libs/rs -I libs/viterbi -I libs/ldpc fec_test.cpp -o fec_test && ./fec_test`


------
https://chatgpt.com/codex/tasks/task_e_68a46b2edf78833099c4b179414b1fbf