### PR TITLE
Fix FEC include paths

### DIFF
--- a/libs/ccsds_link/fec.h
+++ b/libs/ccsds_link/fec.h
@@ -2,9 +2,9 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <vector>
-#include <rs/rs.h>
-#include <viterbi/viterbi.h>
-#include <ldpc/ldpc.h>
+#include "../rs/rs.h"        // код Рида–Соломона
+#include "../viterbi/viterbi.h" // алгоритм Витерби
+#include "../ldpc/ldpc.h"    // LDPC кодирование
 
 // Простейший повторный код R=1/2
 inline void fec_encode_repeat(const uint8_t* in, size_t len, std::vector<uint8_t>& out) {


### PR DESCRIPTION
## Summary
- Исправлены пути подключения библиотек Reed-Solomon, Viterbi и LDPC в `fec.h`
- Добавлены русские комментарии к подключаемым библиотекам

## Testing
- `g++ -std=c++17 -Ilibs/ccsds_link fec_test.cpp libs/rs/rs.cpp libs/viterbi/viterbi.cpp -o fec_test && ./fec_test`


------
https://chatgpt.com/codex/tasks/task_e_68a470e173108330929e1d1e3dabd630