### PR TITLE
Исправлено подключение заголовков в ccsds_link

### DIFF
--- a/libs/ccsds_link/ccsds_link.cpp
+++ b/libs/ccsds_link/ccsds_link.cpp
@@ -1,7 +1,8 @@
 #include "ccsds_link.h"
-#include <scrambler.h>
-#include <fec.h>
-#include <interleaver.h>
+// Подключаем локальные заголовки напрямую, чтобы Arduino не искал их во внешних путях
+#include "scrambler.h"
+#include "fec.h"
+#include "interleaver.h"
 
 namespace ccsds {
 


### PR DESCRIPTION
## Summary
- устранил использование внешних путей при подключении заголовков в `ccsds_link.cpp`
- добавил комментарий о локальном подключении заголовков

## Testing
- `g++ -Ilibs/ccsds_link -c libs/ccsds_link/ccsds_link.cpp`


------
https://chatgpt.com/codex/tasks/task_e_68a478951cb083309326ab1276ea13e2