### PR TITLE
Исправлены пути подключения ccsds_link

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 Reed-Solomon, Viterbi и LDPC из подкаталогов `libs/rs`, `libs/viterbi` и `libs/ldpc`.
 В Arduino IDE скопируйте каталог `libs` в папку `libraries` вашего скетчбука либо
 добавьте его в пути поиска заголовков. После этого подключайте библиотеку так:
-`#include "ccsds_link/ccsds_link.h"` — путь задан относительно каталога `libs`.
+`#include "libs/ccsds_link/ccsds_link.h"` — полный путь до заголовка внутри каталога `libs`.
 
 Начиная с этой версии убраны относительные include-пути вроде `../../scrambler.h`,
 что устраняет ошибку «No such file or directory» при установке библиотеки в Arduino IDE.

--- a/rx_pipeline.cpp
+++ b/rx_pipeline.cpp
@@ -2,7 +2,7 @@
 #include "rx_pipeline.h"
 #include "radio_adapter.h"
 #include "frame_log.h"
-#include "ccsds_link/ccsds_link.h" // заголовок библиотеки CCSDS из каталога libs
+#include "libs/ccsds_link/ccsds_link.h" // заголовок библиотеки CCSDS
 #include "ack_bitmap.h"
 #include "tdd_scheduler.h"
 #include <string.h>

--- a/tx_pipeline.cpp
+++ b/tx_pipeline.cpp
@@ -4,7 +4,7 @@
 #include "config.h"
 #include "radio_adapter.h"
 #include "frame_log.h"
-#include "ccsds_link/ccsds_link.h" // заголовок библиотеки CCSDS из каталога libs
+#include "libs/ccsds_link/ccsds_link.h" // заголовок библиотеки CCSDS
 #include "tdd_scheduler.h"
 #include <Arduino.h>
 #include <string.h>

--- a/tx_profile_test.cpp
+++ b/tx_profile_test.cpp
@@ -2,7 +2,7 @@
 #include <cstdio>
 #define private public
 #include "tx_pipeline.h"
-#include "ccsds_link/ccsds_link.h" // заголовок библиотеки CCSDS из каталога libs
+#include "libs/ccsds_link/ccsds_link.h" // заголовок библиотеки CCSDS
 #undef private
 
 class Print; // заглушка для FrameLog::dump


### PR DESCRIPTION
## Summary
- скорректированы пути `ccsds_link` на `libs/ccsds_link/ccsds_link.h`
- обновлена документация по подключению библиотеки

## Testing
- `g++ -std=c++17 -I. -c rx_pipeline.cpp` *(не найден Arduino.h)*

------
https://chatgpt.com/codex/tasks/task_e_68a4892a3ad88330bf53eb0e7d29b975