### PR TITLE
Подключена ccsds_link и добавлена функция RSSI

### DIFF
--- a/ESP32_LoRa_Pipeline.ino
+++ b/ESP32_LoRa_Pipeline.ino
@@ -43,6 +43,7 @@
 #endif
 
 #include <RadioLib.h>
+#include "libs/ccsds_link/ccsds_link.cpp" // реализация функций encode/decode
 
 static constexpr int PIN_NSS = 5;
 static constexpr int PIN_DIO1 = 26;
@@ -395,6 +396,12 @@ bool Radio_getEbN0(float& ebn0) {
   float snr = radio.getSNR();
   float efficiency = ((float)g_sf * 4.0f / (float)g_cr) / (1 << g_sf); // бит/Гц
   ebn0 = snr - 10.0f * log10f(efficiency);
+  return true;
+}
+
+// Возвращает уровень RSSI последнего принятого пакета
+bool Radio_getRSSI(float& rssi) {
+  rssi = radio.getRSSI();
   return true;
 }
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 - При включённой **AutoRate** значение `PER High` или `Eb/N0 Low` переводит устройство на более надёжный профиль, а `PER Low` и `Eb/N0 High` возвращают к более быстрому. Параметры отправляются на `/setautorate`, `/setperth` и `/setebn0th`.
 - `FrameLog` фиксирует поля `seq`, `fec_mode`, `interleave`, `frag_size`, `snr_db`, `ebn0_db`, `rssi`,
   `rs_corrections`, `viterbi_metric`, `drop_reason`, `rtt_estimate` для каждого кадра.
+- Реализована функция `Radio_getRSSI`, возвращающая уровень сигнала RSSI для последнего приёма.
 
 ## Используемые библиотеки
 - [Arduino core for ESP32](https://github.com/espressif/arduino-esp32) — базовые классы (`Arduino.h`, `Preferences`, `WiFi`, `WebServer`)


### PR DESCRIPTION
## Summary
- Подключена реализация encode/decode из библиотеки `ccsds_link`
- Добавлен метод `Radio_getRSSI` для чтения уровня сигнала
- README дополнен описанием функции RSSI

## Testing
- `g++ -std=c++17 freq_map_test.cpp -I. -o freq_map_test && ./freq_map_test`
- `g++ -std=c++17 interleaver_test.cpp -I. -Ilibs/ccsds_link -o interleaver_test && ./interleaver_test`


------
https://chatgpt.com/codex/tasks/task_e_68a48bdd9da08330bd4db80708d589b4