### PR TITLE
Включено управление RF switch через DIO2

### DIFF
--- a/ESP32_LoRa_Pipeline.ino
+++ b/ESP32_LoRa_Pipeline.ino
@@ -2531,6 +2531,7 @@ void setup() {
   float tcxo = (digitalRead(PIN_TCXO_DETECT) == LOW) ? 2.4f : 0.0f;
 
   int16_t st = radio.begin(g_freq_rx_mhz, g_bw_khz, g_sf, g_cr, 0x18, g_txp, 10, tcxo, false);
+  radio.setDio2AsRfSwitchCtrl(true); // включаем управление RF switch через DIO2
   if (st != RADIOLIB_ERR_NONE) {
     Serial.printf("Radio begin failed: %d\n", st);
   } else {


### PR DESCRIPTION
## Summary
- активировано управление RF switch через DIO2 после `radio.begin`

## Testing
- `./run_key_exchange_test.sh`
- `g++ -std=c++17 freq_map_test.cpp -I. -o freq_map_test && ./freq_map_test`
- `g++ -std=c++17 tx_profile_test.cpp tx_pipeline.cpp message_buffer.cpp fragmenter.cpp test_stubs/Arduino.cpp -DARDUINO_ARCH_ESP32 -I. -Ilibs/ccsds_link -Itest_stubs -o tx_profile_test && ./tx_profile_test`
- `g++ -std=c++17 archive_restore_test.cpp message_buffer.cpp -I. -o archive_restore_test && ./archive_restore_test`
- `./test_web_interface` *(failed: test_web_interface_failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b6809e0483309adb7900a213fe69