### PR TITLE
Реализован зеркальный пинг в radioPoll

### DIFF
--- a/ESP32_LoRa_Pipeline.ino
+++ b/ESP32_LoRa_Pipeline.ino
@@ -413,6 +413,15 @@ static void radioPoll() {
   if (st == RADIOLIB_ERR_NONE) {
     uint8_t tmp[cfg::LORA_MTU];
     int16_t len = radio.readData(tmp, sizeof(tmp));
+    if (len == 5) {
+      // Зеркальный пинг: приёмник немедленно возвращает эти 5 байт
+      // отправителю для проверки канала связи
+      radio.setFrequency(g_freq_tx_mhz);
+      radio.transmit(tmp, 5);
+      radio.setFrequency(g_freq_rx_mhz);
+      radio.startReceive();
+      return; // Не обрабатываем пакет дальше
+    }
     if (len > 0) { Radio_onReceive(tmp, (size_t)len); }
   }
 }


### PR DESCRIPTION
## Summary
- обработаны пакеты длиной 5 байт в radioPoll: устройство отправляет их обратно как зеркальный пинг
- добавлены русские комментарии, поясняющие работу зеркального пинга

## Testing
- `./run_key_exchange_test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a4bc92748c8330aa2a32eaac6f9318