### PR TITLE
Логирование начала TX/RX

### DIFF
--- a/ESP32_LoRa_Pipeline.ino
+++ b/ESP32_LoRa_Pipeline.ino
@@ -376,6 +376,8 @@ static void printMetrics() {
 bool Radio_sendRaw(const uint8_t* data, size_t len) {
   float prev = g_freq_rx_mhz;
   radio.setFrequency(g_freq_tx_mhz);
+  // Логируем начало передачи с указанием частоты
+  chatMsg("SYS", String("TX started ") + String(g_freq_tx_mhz, 3) + " MHz");
   int16_t st = radio.transmit(const_cast<uint8_t*>(data), len);
   radio.setFrequency(prev);
   // После передачи слушаем эфир на окно ACK+guard
@@ -400,6 +402,8 @@ bool Radio_setTxPower(int8_t dBm) {
 void Radio_forceRx(uint32_t rx_ticks) {
   // Запуск приёма с таймаутом в тиках
   radio.startReceive(rx_ticks);
+  // Логируем начало приёма с указанием частоты
+  chatMsg("SYS", String("RX started ") + String(g_freq_rx_mhz, 3) + " MHz");
 }
 
 // Получаем SNR последнего пакета из драйвера


### PR DESCRIPTION
## Summary
- добавить системный лог в чат при запуске передачи с указанием частоты
- добавить системный лог в чат при переходе в режим приёма с указанием частоты

## Testing
- `./run_key_exchange_test.sh`
- `g++ -std=c++17 archive_restore_test.cpp message_buffer.cpp -I. -o archive_restore_test && ./archive_restore_test`
- `g++ -std=c++17 freq_map_test.cpp freq_map.h -I. -o freq_map_test && ./freq_map_test`
- `g++ -std=c++17 frame_header_test.cpp frame.h -I. -o frame_header_test && ./frame_header_test`
- `g++ -std=c++17 interleaver_test.cpp -I. -Ilibs/ccsds_link -o interleaver_test && ./interleaver_test`
- `g++ -std=c++17 fec_test.cpp fec_impl.cpp -I. -Ilibs/ccsds_link -o fec_test && ./fec_test`
- `g++ -std=c++20 compat_ack_test.cpp tx_pipeline.cpp rx_pipeline.cpp fragmenter.cpp message_buffer.cpp frame_log.cpp libs/ccsds_link/ccsds_link.cpp fec_impl.cpp tdd_scheduler.cpp test_stubs/Arduino.cpp test_globals.cpp rssi_stub.cpp -I. -Ilibs/ccsds_link -Itest_stubs -lmbedtls -lmbedcrypto -lmbedx509 -o compat_ack_test && ./compat_ack_test`
- `g++ -std=c++20 tx_profile_test.cpp tx_pipeline.cpp fragmenter.cpp message_buffer.cpp fec_impl.cpp test_stubs/Arduino.cpp -I. -Ilibs/ccsds_link -Itest_stubs -lmbedtls -lmbedcrypto -lmbedx509 -o tx_profile_test && ./tx_profile_test`


------
https://chatgpt.com/codex/tasks/task_e_68a4c523055483308ab3314a332de697