### PR TITLE
Исправлена ошибка компиляции Radio_updateState

### DIFF
--- a/ESP32_LoRa_Pipeline.ino
+++ b/ESP32_LoRa_Pipeline.ino
@@ -23,6 +23,7 @@
 #include "web_style.h"
 #include "web_script.h"
 #include "crypto_spec.h"
+#include "radio_state.h" // состояние радио
 
 #include <string.h> // for memcmp
 #include <ctype.h>   // for toupper when parsing hex strings
@@ -376,9 +377,7 @@ static void printMetrics() {
 
 // --- Управление состоянием радио -------------------------------------------
 
-// Возможные состояния работы радиомодуля
-enum class RadioState { Idle, Rx, Tx };
-
+// Состояния радиомодуля описаны в radio_state.h
 // Текущее состояние; по умолчанию радио в простое
 static RadioState g_radio_state = RadioState::Idle;
 

--- a/radio_state.h
+++ b/radio_state.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <stdint.h>
+
+// Состояние радио: простой, приём или передача
+enum class RadioState : uint8_t { Idle, Rx, Tx };


### PR DESCRIPTION
## Summary
- вынес enum `RadioState` в отдельный заголовок и подключил его в основном скетче
- обновил комментарии о текущем состоянии радиомодуля

## Testing
- `./run_key_exchange_test.sh`
- `g++ -std=c++17 freq_map_test.cpp -o freq_map_test && ./freq_map_test`
- `g++ -std=c++17 frame_header_test.cpp -o frame_header_test && ./frame_header_test`
- `g++ -std=c++17 tx_profile_test.cpp -o tx_profile_test && ./tx_profile_test` *(ошибка линковки)*
- `g++ -std=c++17 compat_ack_test.cpp -o compat_ack_test && ./compat_ack_test` *(ошибка линковки)*
- `g++ -std=c++17 archive_restore_test.cpp -o archive_restore_test && ./archive_restore_test` *(ошибка линковки)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d24accdc833097424e1280fd1617