### PR TITLE
Исправлено возвращение на устаревшую частоту

### DIFF
--- a/ESP32_LoRa_Pipeline.ino
+++ b/ESP32_LoRa_Pipeline.ino
@@ -398,13 +398,14 @@ static void Radio_updateState(RadioState st) {
 
 // Отправка сырых данных по радио
 bool Radio_sendRaw(const uint8_t* data, size_t len) {
-  float prev = g_freq_rx_mhz;
+  // Переключаемся на частоту передачи
   radio.setFrequency(g_freq_tx_mhz);
   // Смена состояния на передачу
   Radio_updateState(RadioState::Tx);
   int16_t st = radio.transmit(const_cast<uint8_t*>(data), len);
   radio.finishTransmit();             // принудительно завершаем передачу
-  radio.setFrequency(prev);
+  // Возвращаемся на актуальную частоту приёма
+  radio.setFrequency(g_freq_rx_mhz);
   // После передачи слушаем эфир на окно ACK+guard
   Radio_forceRx(msToTicks(tdd::ackWindowMs + tdd::guardMs));
   return st == RADIOLIB_ERR_NONE;


### PR DESCRIPTION
## Summary
- Радиомодуль после передачи возвращается на актуальную частоту приёма

## Testing
- `g++ -std=c++17 freq_map_test.cpp -o freq_map_test && ./freq_map_test`
- `g++ -std=c++17 fec_test.cpp fragmenter.cpp encryptor_ccm.cpp fec_impl.cpp -I. -o fec_test && ./fec_test` *(failed: fec.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a57c348628833093d7c865cc6d8ca2