### PR TITLE
Исправлено переключение частот при отправке сообщений

### DIFF
--- a/ESP32_LoRa_Pipeline.ino
+++ b/ESP32_LoRa_Pipeline.ino
@@ -398,14 +398,14 @@ static void Radio_updateState(RadioState st) {
 
 // Отправка сырых данных по радио
 bool Radio_sendRaw(const uint8_t* data, size_t len) {
-  // Переключаемся на частоту передачи
-  radio.setFrequency(g_freq_tx_mhz);
+  // Переключаемся на частоту передачи через обёртку, чтобы избежать ошибок масштаба
+  Radio_setFrequency((uint32_t)(g_freq_tx_mhz * 1e6f));
   // Смена состояния на передачу
   Radio_updateState(RadioState::Tx);
   int16_t st = radio.transmit(const_cast<uint8_t*>(data), len);
   radio.finishTransmit();             // принудительно завершаем передачу
-  // Возвращаемся на актуальную частоту приёма
-  radio.setFrequency(g_freq_rx_mhz);
+  // Возвращаемся на актуальную частоту приёма той же обёрткой
+  Radio_setFrequency((uint32_t)(g_freq_rx_mhz * 1e6f));
   // После передачи слушаем эфир на окно ACK+guard
   Radio_forceRx(msToTicks(tdd::ackWindowMs + tdd::guardMs));
   return st == RADIOLIB_ERR_NONE;


### PR DESCRIPTION
## Summary
- использовать обёртку `Radio_setFrequency` при переключении на TX и обратно на RX, исключая ошибку масштаба

## Testing
- `g++ -std=c++17 freq_map_test.cpp -o freq_map_test && ./freq_map_test`
- `g++ -std=c++17 interleaver_test.cpp libs/ccsds_link/fec.cpp -o interleaver_test && ./interleaver_test` *(отсутствует interleaver.h)*
- `g++ -std=c++17 compat_ack_test.cpp -o compat_ack_test && ./compat_ack_test` *(не найден Arduino.h)*

------
https://chatgpt.com/codex/tasks/task_e_68a5819c65d883309e2c2f4995e14844