### PR TITLE
Добавлен include guard для QoS

### DIFF
--- a/libs/qos.h
+++ b/libs/qos.h
@@ -1,6 +1,11 @@
 #pragma once
+#ifndef LIBS_QOS_H
+#define LIBS_QOS_H
+
 #include <stdint.h>
 
 // Перечисления уровней приоритета QoS и режимов планировщика
 enum class Qos : uint8_t { High=0, Normal=1, Low=2 };
 enum class QosMode : uint8_t { Strict=0, Weighted421=1 };
+
+#endif // LIBS_QOS_H


### PR DESCRIPTION
## Summary
- исправлен заголовочный файл `qos.h` с добавлением include guard, чтобы избежать повторных объявлений перечислений

## Testing
- `g++ -std=c++17 -I . -c tx_engine.cpp` *(ошибка: нет Arduino.h)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c1e1bc188330bc071174ffcbf011