### PR TITLE
исправлена отправка сообщений без сброса частоты

### DIFF
--- a/web_interface.h
+++ b/web_interface.h
@@ -25,7 +25,7 @@ const char WEB_INTERFACE_HTML[] PROGMEM = R"rawliteral(<!DOCTYPE html>
     <div id="chat"></div>
     <div id="inputRow">
       <input id="msg" type="text" placeholder="Введите сообщение">
-      <button id="sendBtn" class="btn-primary" title="Отправить текст по LoRa">Send</button>
+      <button id="sendBtn" type="button" class="btn-primary" title="Отправить текст по LoRa">Send</button><!-- исправлено: кнопка не отправляет форму -->
       <span id="sendStatus"></span>
     </div>
   </div>

--- a/web_script.h
+++ b/web_script.h
@@ -141,7 +141,7 @@ function sendEbn0Th(){const hi=document.getElementById('ebn0High').value;const l
 // Безопасно добавляет обработчики событий и пропускает отсутствующие элементы
 function on(id,ev,fn){const el=document.getElementById(id);if(el)el.addEventListener(ev,fn);}
 // Обработчик отправки сообщения: WebSocket для чата + резервный HTTP
-on('sendBtn','click',()=>{ // QOS: Нормальный Отправка текстового сообщения через чат
+on('sendBtn','click',e=>{e.preventDefault(); // предотвращаем перезагрузку страницы
   const m=document.getElementById('msg').value;
   const st=document.getElementById('sendStatus');
   const btn=document.getElementById('sendBtn');


### PR DESCRIPTION
## Summary
- предотвращён сброс частоты при отправке: кнопка теперь type=button
- добавлен `preventDefault` в обработчик отправки чата

## Testing
- `g++ -std=c++17 test_web_interface.cpp -o test_web_interface && ./test_web_interface && echo test_web_interface OK`
- `g++ -std=c++17 freq_map_test.cpp -o freq_map_test && ./freq_map_test`
- `g++ -std=c++17 tx_profile_test.cpp tx_pipeline.cpp message_buffer.cpp fragmenter.cpp fec_impl.cpp test_stubs/Arduino.cpp -I. -Ilibs -Itest_stubs -o tx_profile_test && ./tx_profile_test`
- `g++ -std=c++17 archive_restore_test.cpp message_buffer.cpp -I. -o archive_restore_test && ./archive_restore_test`
- `./run_key_exchange_test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a5cb9db30483308efbac423d8732dc