### PR TITLE
Fix FEC mode handling in ESP32 pipeline

### DIFF
--- a/ESP32_LoRa_Pipeline.ino
+++ b/ESP32_LoRa_Pipeline.ino
@@ -874,10 +874,10 @@ void handleSetFec() {
     return;
   }
   String v = server.arg("val");
-  TxPipeline::FecMode m;
-  if (v == "off") m = TxPipeline::FEC_OFF;
-  else if (v == "rs_vit") m = TxPipeline::FEC_RS_VIT;
-  else if (v == "ldpc") m = TxPipeline::FEC_LDPC;
+  PacketFormatter::FecMode m;
+  if (v == "off") m = PacketFormatter::FEC_OFF;
+  else if (v == "rs_vit") m = PacketFormatter::FEC_RS_VIT;
+  else if (v == "ldpc") m = PacketFormatter::FEC_LDPC;
   else {
     server.send(400, "text/plain", "off|rs_vit|ldpc");
     return;


### PR DESCRIPTION
## Summary
- корректно используем типы PacketFormatter для установки режима FEC

## Testing
- `./run_key_exchange_test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a5f0d12cc88330a0b8891f3ba794d2