### PR TITLE
Добавлена вместимость буфера и возврат ID сообщений

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 В форке оставлены только базовые компоненты:
 
-- `MessageBuffer` — простой буфер сообщений.
+- `MessageBuffer` — простой буфер сообщений с ограничением по размеру.
 - `TxModule` — передача данных через интерфейс `IRadio`.
 - `RxModule` — приём данных и передача их в пользовательский колбэк.
 - `IRadio` описан в `radio_interface.h`.
@@ -11,9 +11,10 @@
 
 ## API
 ### MessageBuffer
-- `uint32_t enqueue(const uint8_t* data, size_t len)` — добавляет сообщение в буфер.
+- `MessageBuffer(size_t capacity)` — создать буфер с максимальным количеством сообщений.
+- `uint32_t enqueue(const uint8_t* data, size_t len)` — добавляет сообщение в буфер, при переполнении возвращает `0`.
 - `bool hasPending() const` — проверяет наличие сообщений.
-- `bool pop(std::vector<uint8_t>& out)` — извлекает сообщение из очереди.
+- `bool pop(uint32_t& id, std::vector<uint8_t>& out)` — извлекает сообщение и его идентификатор.
 
 ### TxModule
 - `TxModule(IRadio& radio, MessageBuffer& buf)` — инициализация модуля.

--- a/message_buffer.h
+++ b/message_buffer.h
@@ -2,17 +2,21 @@
 #include <deque>
 #include <vector>
 #include <cstdint>
+#include <utility>
 
 // Буфер сообщений для хранения данных на отправку
 class MessageBuffer {
 public:
+  // Конструктор с ограничением на количество сообщений
+  explicit MessageBuffer(size_t capacity);
   // Добавляет сообщение в буфер и возвращает его идентификатор
   uint32_t enqueue(const uint8_t* data, size_t len);
   // Проверяет, есть ли сообщения в очереди
   bool hasPending() const;
-  // Извлекает первое сообщение из очереди
-  bool pop(std::vector<uint8_t>& out);
+  // Извлекает первое сообщение из очереди, возвращает ID и данные
+  bool pop(uint32_t& id, std::vector<uint8_t>& out);
 private:
-  uint32_t next_id_ = 1;                 // следующий идентификатор
-  std::deque<std::vector<uint8_t>> q_;   // очередь сообщений
+  uint32_t next_id_ = 1;                                       // следующий идентификатор
+  size_t capacity_;                                            // максимальное количество сообщений
+  std::deque<std::pair<uint32_t, std::vector<uint8_t>>> q_;    // очередь сообщений с идентификаторами
 };

--- a/tx_module.cpp
+++ b/tx_module.cpp
@@ -13,7 +13,8 @@ uint32_t TxModule::queue(const uint8_t* data, size_t len) {
 void TxModule::loop() {
   if (!buffer_.hasPending()) return;
   std::vector<uint8_t> msg;
-  if (buffer_.pop(msg)) {
+  uint32_t id = 0;                      // получаемый идентификатор сообщения
+  if (buffer_.pop(id, msg)) {
     radio_.send(msg.data(), msg.size());
   }
 }


### PR DESCRIPTION
## Summary
- Добавлен конструктор с указанием максимального количества сообщений и поле `capacity_`
- Очередь хранит пары `ID`+`данные`, проверяется переполнение
- `pop` возвращает ID и данные; обновлён `TxModule`
- README дополнен описанием лимита и возврата ID

## Testing
- `g++ -std=c++17 -c message_buffer.cpp tx_module.cpp rx_module.cpp -I.`

------
https://chatgpt.com/codex/tasks/task_e_68a5fec8bc4c833094059c87f4b49514