### PR TITLE
Fix header guard for MessageBuffer

### DIFF
--- a/message_buffer.h
+++ b/message_buffer.h
@@ -1,4 +1,7 @@
-#pragma once
+// Защита от повторного включения заголовка
+#ifndef MESSAGE_BUFFER_H
+#define MESSAGE_BUFFER_H
+
 #include <deque>
 #include <vector>
 #include <cstdint>
@@ -20,3 +23,5 @@ private:
   size_t capacity_;                                            // максимальное количество сообщений
   std::deque<std::pair<uint32_t, std::vector<uint8_t>>> q_;    // очередь сообщений с идентификаторами
 };
+
+#endif // MESSAGE_BUFFER_H


### PR DESCRIPTION
## Summary
- add classic include guard to MessageBuffer header to avoid redefinition

## Testing
- `g++ -std=c++17 -I. message_buffer.cpp tests/test_message_buffer.cpp -o tests/test_message_buffer && tests/test_message_buffer`
- `g++ -std=c++17 -I. -Ilibs message_buffer.cpp libs/packetizer/packet_splitter.cpp tests/test_packet_splitter.cpp -o tests/test_packet_splitter && tests/test_packet_splitter`
- `g++ -std=c++17 -I. -Ilibs message_buffer.cpp libs/packetizer/packet_splitter.cpp libs/frame/frame_header.cpp tx_module.cpp tests/test_tx_module.cpp -o tests/test_tx_module && tests/test_tx_module`


------
https://chatgpt.com/codex/tasks/task_e_68a8394416d083308f9d2de318808f4f