### PR TITLE
Обработка ошибки команды TX

### DIFF
--- a/serial_radio_control.ino
+++ b/serial_radio_control.ino
@@ -85,9 +85,14 @@ void loop() {
         Serial.print("Power: "); Serial.print(radio.getPower()); Serial.println(" dBm");
       } else if (line.startsWith("TX ")) {
         String msg = line.substring(3);
-        tx.queue((const uint8_t*)msg.c_str(), msg.length());
-        tx.loop();
-        Serial.println("Пакет отправлен");
+        // помещаем сообщение в очередь и проверяем успех
+        uint32_t id = tx.queue((const uint8_t*)msg.c_str(), msg.length());
+        if (id != 0) {
+          tx.loop();                           // отправляем первый пакет
+          Serial.println("Пакет отправлен");
+        } else {
+          Serial.println("Ошибка постановки пакета в очередь");
+        }
       }
     }
 }


### PR DESCRIPTION
## Summary
- добавлена проверка результата постановки сообщения в очередь для команды `TX`
- выводится ошибка, если буфер переполнен

## Testing
- `g++ -std=c++17 -I. tests/test_message_buffer.cpp message_buffer.cpp libs/packetizer/packet_splitter.cpp -o /tmp/test_mb && /tmp/test_mb`
- `g++ -std=c++17 -I. -Ilibs tests/test_packet_splitter.cpp message_buffer.cpp libs/packetizer/packet_splitter.cpp -o /tmp/test_ps && /tmp/test_ps`
- `g++ -std=c++17 -I. -Ilibs tests/test_tx_module.cpp message_buffer.cpp libs/packetizer/packet_splitter.cpp tx_module.cpp libs/frame/frame_header.cpp -o /tmp/test_tx && /tmp/test_tx`
- `g++ -std=c++17 -I. -Ilibs tests/test_full_flow.cpp message_buffer.cpp libs/packetizer/packet_splitter.cpp tx_module.cpp libs/frame/frame_header.cpp rx_module.cpp libs/packetizer/packet_gatherer.cpp -lpthread -o /tmp/test_ff && /tmp/test_ff`


------
https://chatgpt.com/codex/tasks/task_e_68a860e9710c83309b17f698bbd5a96b