### PR TITLE
Fix ChannelBank multiple definition

### DIFF
--- a/channel_bank.h
+++ b/channel_bank.h
@@ -1,0 +1,5 @@
+#pragma once
+
+// Перечисление банков каналов
+enum class ChannelBank { EAST, WEST, TEST };
+

--- a/default_settings.h
+++ b/default_settings.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <cstdint>
-
-enum class ChannelBank { EAST, WEST, TEST }; // Банк каналов
+#include "channel_bank.h" // Банк каналов
 
 // Значения параметров радиомодуля по умолчанию
 namespace DefaultSettings {

--- a/radio_sx1262.h
+++ b/radio_sx1262.h
@@ -3,9 +3,7 @@
 #include <vector>
 #include <cstdint>
 #include "radio_interface.h"
-
-// Банк каналов
-enum class ChannelBank { EAST, WEST, TEST };
+#include "channel_bank.h"
 
 // Реализация радиоинтерфейса на базе SX1262
 class RadioSX1262 : public IRadio {


### PR DESCRIPTION
## Summary
- extract ChannelBank enum into separate `channel_bank.h`
- include new header in `radio_sx1262.h` and `default_settings.h`

## Testing
- `g++ -std=c++17 -I . tests/test_message_buffer.cpp message_buffer.cpp -o test_message_buffer && ./test_message_buffer`
- `g++ -std=c++17 -I . -I libs tests/test_tx_module.cpp tx_module.cpp message_buffer.cpp libs_includes.cpp -o test_tx_module && ./test_tx_module`
- `g++ -std=c++17 -I . -I libs tests/test_packet_splitter.cpp message_buffer.cpp libs_includes.cpp -o test_packet_splitter && ./test_packet_splitter`
- `g++ -std=c++17 -pthread -I . -I libs tests/test_full_flow.cpp tx_module.cpp rx_module.cpp message_buffer.cpp libs/packetizer/packet_gatherer.cpp libs/packetizer/packet_splitter.cpp libs/frame/frame_header.cpp -o test_full_flow && ./test_full_flow`


------
https://chatgpt.com/codex/tasks/task_e_68a86cd931f8833088d4a236e3103a10