### PR TITLE
Добавить фильтрацию логов

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - `RadioSX1262` — конкретная реализация интерфейса на базе модуля SX1262.
 - `SerialProgramCollector` — библиотека для приёма строк по Serial и сборки их в один буфер (`libs/serial_program_collector/`).
   - `serial_radio_control.ino` — пример настройки банков каналов, BW, SF, CR и мощности через Serial, вывода текущих параметров и отправки тестовых пакетов через `TxModule`.
-- Для отладочных сообщений предусмотрен флаг `DefaultSettings::DEBUG` и макросы `DEBUG_LOG`, `DEBUG_LOG_VAL`.
+- Для отладочных сообщений предусмотрен флаг `DefaultSettings::DEBUG` и уровни журналирования `DefaultSettings::LOG_LEVEL`. Доступны макросы `LOG_ERROR`, `LOG_WARN`, `LOG_INFO`, `DEBUG_LOG` и их варианты с выводом значения (`*_VAL`) для фильтрации лишнего спама.
 
 Все сторонние библиотеки расположены в каталоге `libs/`.
 Для корректной сборки в Arduino добавлен вспомогательный файл `libs_includes.cpp`,

--- a/default_settings.h
+++ b/default_settings.h
@@ -10,22 +10,40 @@ namespace DefaultSettings {
   constexpr uint8_t BW_PRESET = 3;                // Индекс полосы
   constexpr uint8_t SF_PRESET = 2;                // Индекс фактора расширения
   constexpr uint8_t CR_PRESET = 0;                // Индекс коэффициента кодирования
-  constexpr bool DEBUG = true;                    // Флаг отладочного вывода
-}
+    constexpr bool DEBUG = true;                    // Флаг отладочного вывода
+    // Уровни журналирования для фильтрации сообщений
+    enum class LogLevel : uint8_t { ERROR = 0, WARN = 1, INFO = 2, DEBUG = 3 };
+    constexpr LogLevel LOG_LEVEL = LogLevel::INFO;   // Текущий уровень вывода
+  }
 
-#if !defined(DEBUG_LOG)
+#if !defined(LOG_MSG)
 #  if defined(ARDUINO)
 #    include <Arduino.h>
-#    define DEBUG_LOG(msg) do { if (DefaultSettings::DEBUG) Serial.println(msg); } while (0)
-#    define DEBUG_LOG_VAL(prefix, val) do { \
-      if (DefaultSettings::DEBUG) { Serial.print(prefix); Serial.println(val); } \
+#    define LOG_MSG(level, msg) do { \
+      if (DefaultSettings::DEBUG && level <= DefaultSettings::LOG_LEVEL) Serial.println(msg); \
+    } while (0)
+#    define LOG_MSG_VAL(level, prefix, val) do { \
+      if (DefaultSettings::DEBUG && level <= DefaultSettings::LOG_LEVEL) { \
+        Serial.print(prefix); Serial.println(val); \
+      } \
     } while (0)
 #  else
 #    include <iostream>
-#    define DEBUG_LOG(msg) do { if (DefaultSettings::DEBUG) std::cout << msg << std::endl; } while (0)
-#    define DEBUG_LOG_VAL(prefix, val) do { \
-      if (DefaultSettings::DEBUG) std::cout << prefix << val << std::endl; \
+#    define LOG_MSG(level, msg) do { \
+      if (DefaultSettings::DEBUG && level <= DefaultSettings::LOG_LEVEL) std::cout << msg << std::endl; \
+    } while (0)
+#    define LOG_MSG_VAL(level, prefix, val) do { \
+      if (DefaultSettings::DEBUG && level <= DefaultSettings::LOG_LEVEL) \
+        std::cout << prefix << val << std::endl; \
     } while (0)
 #  endif
+#  define LOG_ERROR(msg) LOG_MSG(DefaultSettings::LogLevel::ERROR, msg)
+#  define LOG_WARN(msg)  LOG_MSG(DefaultSettings::LogLevel::WARN,  msg)
+#  define LOG_INFO(msg)  LOG_MSG(DefaultSettings::LogLevel::INFO,  msg)
+#  define DEBUG_LOG(msg) LOG_MSG(DefaultSettings::LogLevel::DEBUG, msg)
+#  define LOG_ERROR_VAL(prefix, val) LOG_MSG_VAL(DefaultSettings::LogLevel::ERROR, prefix, val)
+#  define LOG_WARN_VAL(prefix, val)  LOG_MSG_VAL(DefaultSettings::LogLevel::WARN,  prefix, val)
+#  define LOG_INFO_VAL(prefix, val)  LOG_MSG_VAL(DefaultSettings::LogLevel::INFO,  prefix, val)
+#  define DEBUG_LOG_VAL(prefix, val) LOG_MSG_VAL(DefaultSettings::LogLevel::DEBUG, prefix, val)
 #endif
 


### PR DESCRIPTION
## Summary
- add log level filtering and macros to control verbosity
- document log levels and macros in README

## Testing
- `g++ -std=c++17 -I. tests/test_message_buffer.cpp message_buffer.cpp -o /tmp/test_message_buffer && /tmp/test_message_buffer`
- `g++ -std=c++17 -I. -I libs tests/test_packet_splitter.cpp message_buffer.cpp libs/packetizer/packet_splitter.cpp -o /tmp/test_packet_splitter && /tmp/test_packet_splitter`
- `g++ -std=c++17 -I. -I libs tests/test_tx_module.cpp tx_module.cpp message_buffer.cpp libs/packetizer/packet_splitter.cpp libs/frame/frame_header.cpp -o /tmp/test_tx_module && /tmp/test_tx_module`
- `g++ -std=c++17 -I. -I libs tests/test_full_flow.cpp tx_module.cpp rx_module.cpp message_buffer.cpp libs/packetizer/packet_splitter.cpp libs/packetizer/packet_gatherer.cpp libs/frame/frame_header.cpp -o /tmp/test_full_flow && /tmp/test_full_flow`


------
https://chatgpt.com/codex/tasks/task_e_68a8967da2148330b65005697b800c9b