### PR TITLE
Add pointer validation to radio and packet modules

### DIFF
--- a/radio_sx1262.cpp
+++ b/radio_sx1262.cpp
@@ -30,13 +30,17 @@ bool RadioSX1262::begin() {
 }
 
 void RadioSX1262::send(const uint8_t* data, size_t len) {
+  if (!data || len == 0) {                   // проверка указателя и длины
+    DEBUG_LOG("RadioSX1262: пустая передача");
+    return;
+  }
   float freq_tx = fTX_bank_[static_cast<int>(bank_)][channel_];
   float freq_rx = fRX_bank_[static_cast<int>(bank_)][channel_];
   DEBUG_LOG_VAL("RadioSX1262: отправка длины=", len);
-  radio_.setFrequency(freq_tx);        // переключаемся на TX частоту
+  radio_.setFrequency(freq_tx);              // переключаемся на TX частоту
   radio_.transmit((uint8_t*)data, len);
-  radio_.setFrequency(freq_rx);        // возвращаем частоту приёма
-  radio_.startReceive();               // и продолжаем слушать эфир
+  radio_.setFrequency(freq_rx);              // возвращаем частоту приёма
+  radio_.startReceive();                     // и продолжаем слушать эфир
   DEBUG_LOG("RadioSX1262: передача завершена");
 }
 

--- a/rx_module.cpp
+++ b/rx_module.cpp
@@ -5,6 +5,9 @@
 // Удаление пилотов из полезной нагрузки
 static std::vector<uint8_t> removePilots(const uint8_t* data, size_t len) {
   std::vector<uint8_t> out;
+  if (!data || len == 0) {               // проверка указателя и длины
+    return out;
+  }
   out.reserve(len);
   size_t count = 0;
   for (size_t i = 0; i < len; ++i) {
@@ -20,7 +23,7 @@ static std::vector<uint8_t> removePilots(const uint8_t* data, size_t len) {
 
 // Передаём данные колбэку, если заголовок валиден
 void RxModule::onReceive(const uint8_t* data, size_t len) {
-  if (!cb_ || len < FrameHeader::SIZE * 2) return;
+  if (!cb_ || !data || len < FrameHeader::SIZE * 2) return; // проверка указателя
 
   FrameHeader hdr;
   bool ok = FrameHeader::decode(data, len, hdr);

--- a/tx_module.cpp
+++ b/tx_module.cpp
@@ -31,6 +31,10 @@ void TxModule::setPayloadMode(PayloadMode mode) { splitter_.setMode(mode); }
 
 // Помещаем сообщение в буфер через делитель
 uint32_t TxModule::queue(const uint8_t* data, size_t len) {
+  if (!data || len == 0) {                        // проверка указателя
+    DEBUG_LOG("TxModule: пустой ввод");
+    return 0;
+  }
   DEBUG_LOG_VAL("TxModule: постановка длины=", len);
   uint32_t res = splitter_.splitAndEnqueue(buffer_, data, len);
   if (res) {


### PR DESCRIPTION
## Summary
- handle null pointers and empty data in RxModule
- guard RadioSX1262 send against invalid buffers
- validate input before queuing packets in TxModule

## Testing
- `g++ -std=c++17 tests/test_message_buffer.cpp message_buffer.cpp -I. -o test_message_buffer && ./test_message_buffer`
- `g++ -std=c++17 tests/test_packet_splitter.cpp message_buffer.cpp libs/packetizer/packet_splitter.cpp -I. -Ilibs -o test_packet_splitter && ./test_packet_splitter`
- `g++ -std=c++17 tests/test_tx_module.cpp tx_module.cpp message_buffer.cpp libs/packetizer/packet_splitter.cpp libs/frame/frame_header.cpp -I. -Ilibs -o test_tx_module && ./test_tx_module`
- `g++ -std=c++17 tests/test_full_flow.cpp tx_module.cpp rx_module.cpp message_buffer.cpp libs/packetizer/packet_splitter.cpp libs/packetizer/packet_gatherer.cpp libs/frame/frame_header.cpp -I. -Ilibs -pthread -o test_full_flow && ./test_full_flow`


------
https://chatgpt.com/codex/tasks/task_e_68a8990d2478833091ce0b69d7976b00