### PR TITLE
Проверка кода ошибки transmit в RadioSX1262

### DIFF
--- a/radio_sx1262.cpp
+++ b/radio_sx1262.cpp
@@ -39,7 +39,11 @@ void RadioSX1262::send(const uint8_t* data, size_t len) {
   float freq_rx = fRX_bank_[static_cast<int>(bank_)][channel_];
   DEBUG_LOG_VAL("RadioSX1262: отправка длины=", len);
   radio_.setFrequency(freq_tx);              // переключаемся на TX частоту
-  radio_.transmit((uint8_t*)data, len);
+  int state = radio_.transmit((uint8_t*)data, len); // отправляем пакет
+  if (state != RADIOLIB_ERR_NONE) {          // проверка кода ошибки
+    LOG_ERROR_VAL("RadioSX1262: ошибка передачи, код=", state);
+    return;                                  // выходим без смены частоты
+  }
   radio_.setFrequency(freq_rx);              // возвращаем частоту приёма
   radio_.startReceive();                     // и продолжаем слушать эфир
   DEBUG_LOG("RadioSX1262: передача завершена");


### PR DESCRIPTION
## Summary
- проверить результат `radio_.transmit`
- при ошибке выводить сообщение и не менять частоту приёма

## Testing
- `g++ -std=c++17 -c radio_sx1262.cpp` *(ошибка: RadioLib.h отсутствует)*
- `g++ -std=c++17 tests/test_message_buffer.cpp message_buffer.cpp -I. -o tests/test_message_buffer`
- `./tests/test_message_buffer`
- `g++ -std=c++17 tests/test_packet_splitter.cpp message_buffer.cpp libs/packetizer/packet_splitter.cpp -I. -Ilibs -Ilibs/packetizer -o tests/test_packet_splitter`
- `./tests/test_packet_splitter`
- `g++ -std=c++17 tests/test_text_converter.cpp libs/text_converter/text_converter.cpp -Ilibs/text_converter -o tests/test_text_converter`
- `./tests/test_text_converter`
- `g++ -std=c++17 tests/test_tx_module.cpp tx_module.cpp message_buffer.cpp libs/frame/frame_header.cpp libs/packetizer/packet_splitter.cpp -I. -Ilibs/frame -Ilibs/packetizer -o tests/test_tx_module`
- `./tests/test_tx_module`
- `g++ -std=c++17 tests/test_full_flow.cpp tx_module.cpp rx_module.cpp message_buffer.cpp libs/frame/frame_header.cpp libs/packetizer/packet_splitter.cpp libs/packetizer/packet_gatherer.cpp -I. -Ilibs -Ilibs/frame -Ilibs/packetizer -o tests/test_full_flow`
- `./tests/test_full_flow`


------
https://chatgpt.com/codex/tasks/task_e_68a8bc862f608330911a70e1f5867734