### PR TITLE
Добавлен сброс буфера логов

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - `SerialProgramCollector` — библиотека для приёма строк по Serial и сборки их в один буфер (`libs/serial_program_collector/`).
   - `serial_radio_control.ino` — пример настройки банков каналов, BW, SF, CR и мощности через Serial, вывода текущих параметров и отправки тестовых пакетов через `TxModule`.
 - `TextConverter` — библиотека (`libs/text_converter/`) для преобразования UTF-8 текста в байты CP1251, используемая командой `TX`.
-- Для отладочных сообщений предусмотрен флаг `DefaultSettings::DEBUG` и уровни журналирования `DefaultSettings::LOG_LEVEL`. Доступны макросы `LOG_ERROR`, `LOG_WARN`, `LOG_INFO`, `DEBUG_LOG` и их варианты с выводом значения (`*_VAL`) для фильтрации лишнего спама.
+- Для отладочных сообщений предусмотрен флаг `DefaultSettings::DEBUG` и уровни журналирования `DefaultSettings::LOG_LEVEL`. Доступны макросы `LOG_ERROR`, `LOG_WARN`, `LOG_INFO`, `DEBUG_LOG` и их варианты с выводом значения (`*_VAL`) для фильтрации лишнего спама. Макросы на Arduino дополнительно вызывают `Serial.flush()`, чтобы не терять часть вывода.
 
 Все сторонние библиотеки расположены в каталоге `libs/`.
 Для корректной сборки в Arduino добавлен вспомогательный файл `libs_includes.cpp`,

--- a/default_settings.h
+++ b/default_settings.h
@@ -19,19 +19,27 @@ namespace DefaultSettings {
 #if !defined(LOG_MSG)
 #  if defined(ARDUINO)
 #    include <Arduino.h>
+// Вывод сообщения с принудительным сбросом буфера Serial
 #    define LOG_MSG(level, msg) do { \
-      if (DefaultSettings::DEBUG && level <= DefaultSettings::LOG_LEVEL) Serial.println(msg); \
+      if (DefaultSettings::DEBUG && level <= DefaultSettings::LOG_LEVEL) { \
+        Serial.println(msg); \
+        Serial.flush(); \
+      } \
     } while (0)
+// Вывод значения с префиксом и сбросом буфера Serial
 #    define LOG_MSG_VAL(level, prefix, val) do { \
       if (DefaultSettings::DEBUG && level <= DefaultSettings::LOG_LEVEL) { \
         Serial.print(prefix); Serial.println(val); \
+        Serial.flush(); \
       } \
     } while (0)
 #  else
 #    include <iostream>
+// Вывод сообщения в стандартный поток с окончанием строки
 #    define LOG_MSG(level, msg) do { \
       if (DefaultSettings::DEBUG && level <= DefaultSettings::LOG_LEVEL) std::cout << msg << std::endl; \
     } while (0)
+// Вывод значения с префиксом в стандартный поток
 #    define LOG_MSG_VAL(level, prefix, val) do { \
       if (DefaultSettings::DEBUG && level <= DefaultSettings::LOG_LEVEL) \
         std::cout << prefix << val << std::endl; \


### PR DESCRIPTION
## Summary
- принудительно сбрасываем буфер Serial в макросах логирования для Arduino
- документировали поведение макросов в README

## Testing
- `g++ -std=c++17 tests/test_text_converter.cpp libs/text_converter/text_converter.cpp -I . -I libs -o tests/bin/test_text_converter && tests/bin/test_text_converter`
- `g++ -std=c++17 tests/test_message_buffer.cpp message_buffer.cpp -I . -I libs -o tests/bin/test_message_buffer && tests/bin/test_message_buffer`
- `g++ -std=c++17 tests/test_packet_splitter.cpp message_buffer.cpp libs/packetizer/packet_splitter.cpp -I . -I libs -o tests/bin/test_packet_splitter && tests/bin/test_packet_splitter`
- `g++ -std=c++17 tests/test_tx_module.cpp tx_module.cpp message_buffer.cpp libs/frame/frame_header.cpp libs/packetizer/packet_splitter.cpp -I . -I libs -o tests/bin/test_tx_module && tests/bin/test_tx_module`
- `g++ -std=c++17 tests/test_full_flow.cpp tx_module.cpp rx_module.cpp message_buffer.cpp libs/frame/frame_header.cpp libs/packetizer/packet_splitter.cpp libs/packetizer/packet_gatherer.cpp -I . -I libs -lpthread -o tests/bin/test_full_flow && tests/bin/test_full_flow`


------
https://chatgpt.com/codex/tasks/task_e_68a8c16e8808833095f7cc977bb6e6fd