### PR TITLE
feat: add byte interleaver

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   - `serial_radio_control.ino` — пример настройки банков каналов, BW, SF, CR и мощности через Serial, вывода текущих параметров и отправки тестовых пакетов через `TxModule`.
 - `TextConverter` — библиотека (`libs/text_converter/`) для преобразования UTF-8 текста в байты CP1251, используемая командой `TX`.
 - `rs255223` — библиотека (`libs/rs255223/`) с обёртками `encode()` и `decode()` для кода Рида–Соломона RS(255,223).
+- `byte_interleaver` — библиотека (`libs/byte_interleaver/`) с функциями `interleave()` и `deinterleave()` для байтового перемежения.
 - Для отладочных сообщений предусмотрен флаг `DefaultSettings::DEBUG` и уровни журналирования `DefaultSettings::LOG_LEVEL`. Доступны макросы `LOG_ERROR`, `LOG_WARN`, `LOG_INFO`, `DEBUG_LOG` и их варианты с выводом значения (`*_VAL`) для фильтрации лишнего спама. Макросы на Arduino дополнительно вызывают `Serial.flush()`, чтобы не терять часть вывода.
 
 Все сторонние библиотеки расположены в каталоге `libs/`.
@@ -55,8 +56,8 @@
 ### RxModule
 - `void setCallback(RxModule::Callback cb)` — установить обработчик входящих данных.
 - `void onReceive(const uint8_t* data, size_t len)` — принять кадр, проверить CRC и передать полезные данные обработчику.
-- В `TxModule` перед интерливингом вызывается `rs255223::encode()`,
-  в `RxModule` после деинтерливинга вызывается `rs255223::decode()`.
+- После кодера RS применяется `byte_interleaver::interleave()`,
+  перед декодером RS — `byte_interleaver::deinterleave()`.
 
 ### RadioSX1262
   - `bool begin()` — инициализация радиомодуля с автоматическим возвратом параметров к значениям по умолчанию.

--- a/libs/byte_interleaver/byte_interleaver.cpp
+++ b/libs/byte_interleaver/byte_interleaver.cpp
@@ -1,0 +1,39 @@
+#include "byte_interleaver.h"
+#include <vector>
+
+namespace {
+// Фиксированная глубина интерливинга
+static constexpr size_t DEPTH = 8;
+}
+
+namespace byte_interleaver {
+// Перемежение байтов в буфере
+void interleave(uint8_t* buf, size_t len) {
+  if (!buf || DEPTH <= 1) return;            // проверка указателя и глубины
+  size_t cols = (len + DEPTH - 1) / DEPTH;   // число столбцов матрицы
+  std::vector<uint8_t> matrix(DEPTH * cols, 0);
+  for (size_t i = 0; i < len; ++i) matrix[i] = buf[i];
+  size_t k = 0;
+  for (size_t c = 0; c < cols; ++c) {
+    for (size_t r = 0; r < DEPTH; ++r) {
+      size_t idx = r * cols + c;
+      if (idx < len) buf[k++] = matrix[idx];
+    }
+  }
+}
+
+// Обратное перемежение буфера
+void deinterleave(uint8_t* buf, size_t len) {
+  if (!buf || DEPTH <= 1) return;            // проверка указателя и глубины
+  size_t cols = (len + DEPTH - 1) / DEPTH;   // число столбцов матрицы
+  std::vector<uint8_t> matrix(DEPTH * cols, 0);
+  size_t k = 0;
+  for (size_t c = 0; c < cols; ++c) {
+    for (size_t r = 0; r < DEPTH; ++r) {
+      size_t idx = r * cols + c;
+      if (idx < len && k < len) matrix[idx] = buf[k++];
+    }
+  }
+  for (size_t i = 0; i < len; ++i) buf[i] = matrix[i];
+}
+}

--- a/libs/byte_interleaver/byte_interleaver.h
+++ b/libs/byte_interleaver/byte_interleaver.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <cstdint>
+#include <cstddef>
+
+// Простые функции байтового интерливинга с фиксированной глубиной
+namespace byte_interleaver {
+// Перемежение байтов в буфере
+void interleave(uint8_t* buf, size_t len);
+// Обратное перемежение буфера
+void deinterleave(uint8_t* buf, size_t len);
+}

--- a/libs_includes.cpp
+++ b/libs_includes.cpp
@@ -4,3 +4,4 @@
 #include "libs/text_converter/text_converter.cpp"
 #include "libs/rs/rs.cpp"            // базовая реализация RS(255,223)
 #include "libs/rs255223/rs255223.cpp" // обёртки encode/decode
+#include "libs/byte_interleaver/byte_interleaver.cpp" // байтовый интерливинг


### PR DESCRIPTION
## Summary
- add simple byte interleaver library
- wire interleaving around Reed-Solomon codec
- document new interleaving step in README

## Testing
- `g++ -std=c++17 -I. tests/test_message_buffer.cpp message_buffer.cpp -o test_message_buffer && ./test_message_buffer`
- `g++ -std=c++17 -I. -Ilibs tests/test_packet_splitter.cpp libs/packetizer/packet_splitter.cpp message_buffer.cpp -o test_packet_splitter && ./test_packet_splitter`
- `g++ -std=c++17 -I. -Ilibs tests/test_text_converter.cpp libs/text_converter/text_converter.cpp -o test_text_converter && ./test_text_converter`
- `g++ -std=c++17 -I. -Ilibs tests/test_tx_module.cpp tx_module.cpp message_buffer.cpp libs/packetizer/packet_splitter.cpp libs/frame/frame_header.cpp libs/byte_interleaver/byte_interleaver.cpp libs/rs/rs.cpp libs/rs255223/rs255223.cpp -o test_tx_module && ./test_tx_module`
- `g++ -std=c++17 -I. -Ilibs tests/test_full_flow.cpp tx_module.cpp rx_module.cpp message_buffer.cpp libs/packetizer/packet_splitter.cpp libs/packetizer/packet_gatherer.cpp libs/frame/frame_header.cpp libs/byte_interleaver/byte_interleaver.cpp libs/rs/rs.cpp libs/rs255223/rs255223.cpp -o test_full_flow && ./test_full_flow`


------
https://chatgpt.com/codex/tasks/task_e_68a8c59d11808330ab5f1c58070d12ac