### PR TITLE
Добавлены свёрточный кодер и битовый интерливинг

### DIFF
--- a/libs/bit_interleaver/bit_interleaver.cpp
+++ b/libs/bit_interleaver/bit_interleaver.cpp
@@ -1,0 +1,57 @@
+#include "bit_interleaver.h"
+#include <vector>
+#include <cstring>
+
+namespace {
+// Глубина интерливинга по умолчанию
+static constexpr size_t BDEPTH = 8;
+}
+
+namespace bit_interleaver {
+// Перемежение бит в буфере
+void interleave(uint8_t* buf, size_t len) {
+  if (!buf || BDEPTH <= 1) return; // проверка указателя и глубины
+  size_t total_bits = len * 8;
+  size_t cols = (total_bits + BDEPTH - 1) / BDEPTH;
+  std::vector<uint8_t> matrix(BDEPTH * cols, 0);
+  // Раскладываем биты по матрице
+  for (size_t i = 0; i < total_bits; ++i) {
+    uint8_t bit = (buf[i >> 3] >> (7 - (i & 7))) & 1;
+    matrix[i] = bit;
+  }
+  std::memset(buf, 0, len); // очищаем исходный буфер
+  size_t k = 0;
+  for (size_t c = 0; c < cols; ++c) {
+    for (size_t r = 0; r < BDEPTH; ++r) {
+      size_t idx = r * cols + c;
+      if (idx < total_bits) {
+        if (matrix[idx]) buf[k >> 3] |= (1 << (7 - (k & 7)));
+        ++k;
+      }
+    }
+  }
+}
+
+// Обратное перемежение бит в буфере
+void deinterleave(uint8_t* buf, size_t len) {
+  if (!buf || BDEPTH <= 1) return; // проверка указателя и глубины
+  size_t total_bits = len * 8;
+  size_t cols = (total_bits + BDEPTH - 1) / BDEPTH;
+  std::vector<uint8_t> matrix(BDEPTH * cols, 0);
+  size_t k = 0;
+  for (size_t c = 0; c < cols; ++c) {
+    for (size_t r = 0; r < BDEPTH; ++r) {
+      size_t idx = r * cols + c;
+      if (idx < total_bits) {
+        uint8_t bit = (buf[k >> 3] >> (7 - (k & 7))) & 1;
+        matrix[idx] = bit;
+        ++k;
+      }
+    }
+  }
+  std::memset(buf, 0, len);
+  for (size_t i = 0; i < total_bits; ++i) {
+    if (matrix[i]) buf[i >> 3] |= (1 << (7 - (i & 7)));
+  }
+}
+} // namespace bit_interleaver

--- a/libs/bit_interleaver/bit_interleaver.h
+++ b/libs/bit_interleaver/bit_interleaver.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <cstddef>
+#include <cstdint>
+
+// Битовый интерливинг фиксированной глубины
+namespace bit_interleaver {
+// Перемежение бит внутри буфера (len — количество байт)
+void interleave(uint8_t* buf, size_t len);
+// Обратное перемежение бит
+void deinterleave(uint8_t* buf, size_t len);
+}

--- a/libs/conv_codec/conv_codec.cpp
+++ b/libs/conv_codec/conv_codec.cpp
@@ -1,0 +1,16 @@
+#include "conv_codec.h"
+#include "../viterbi/viterbi.h"
+
+namespace conv_codec {
+// Простейшая обёртка над существующей реализацией
+void encodeBits(const uint8_t* data, size_t len, std::vector<uint8_t>& out) {
+  if (!data || len == 0) return; // проверка входа
+  vit::encode(data, len, out);
+}
+
+// Декодер Витерби для жёстких решений
+bool viterbiDecode(const uint8_t* data, size_t len, std::vector<uint8_t>& out) {
+  if (!data || len == 0) return false; // проверка входа
+  return vit::decode(data, len, out);
+}
+} // namespace conv_codec

--- a/libs/conv_codec/conv_codec.h
+++ b/libs/conv_codec/conv_codec.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+// Обёртки для свёрточного кодера и декодера Витерби
+namespace conv_codec {
+// Кодирование бит (байты трактуются как последовательность бит)
+void encodeBits(const uint8_t* data, size_t len, std::vector<uint8_t>& out);
+// Декодирование алгоритмом Витерби (жёсткие решения)
+bool viterbiDecode(const uint8_t* data, size_t len, std::vector<uint8_t>& out);
+}

--- a/libs_includes.cpp
+++ b/libs_includes.cpp
@@ -1,7 +1,11 @@
 // Этот файл подключает реализации библиотек, чтобы Arduino-сборка видела их определения
 #include "libs/packetizer/packet_splitter.cpp"
+#include "libs/packetizer/packet_gatherer.cpp"     // собиратель пакетов
 #include "libs/frame/frame_header.cpp"
 #include "libs/text_converter/text_converter.cpp"
 #include "libs/rs/rs.cpp"            // базовая реализация RS(255,223)
 #include "libs/rs255223/rs255223.cpp" // обёртки encode/decode
 #include "libs/byte_interleaver/byte_interleaver.cpp" // байтовый интерливинг
+#include "libs/viterbi/viterbi.cpp"                  // сверточный кодер
+#include "libs/conv_codec/conv_codec.cpp"           // обёртки encodeBits/viterbiDecode
+#include "libs/bit_interleaver/bit_interleaver.cpp" // битовый интерливинг

--- a/tx_module.cpp
+++ b/tx_module.cpp
@@ -2,6 +2,9 @@
 #include "libs/frame/frame_header.h" // заголовок кадра
 #include "libs/rs255223/rs255223.h"    // RS(255,223)
 #include "libs/byte_interleaver/byte_interleaver.h" // байтовый интерливинг
+#include "libs/conv_codec/conv_codec.h" // свёрточное кодирование
+#include "libs/bit_interleaver/bit_interleaver.h" // битовый интерливинг
+#include "libs/ccsds_link/scrambler.h" // скремблер
 #include "default_settings.h"
 #include <vector>
 #include <chrono>
@@ -10,6 +13,7 @@
 static constexpr size_t MAX_FRAME_SIZE = 255;      // максимально допустимый кадр
 static constexpr size_t RS_DATA_LEN = 223;         // длина блока данных RS
 static constexpr size_t RS_ENC_LEN = 255;         // длина закодированного блока
+static constexpr bool USE_BIT_INTERLEAVER = true; // включение битового интерливинга
 
 // Вставка пилотов каждые 64 байта
 static std::vector<uint8_t> insertPilots(const std::vector<uint8_t>& in) {
@@ -78,15 +82,21 @@ void TxModule::loop() {
     return;
   }
 
-  // Кодирование RS и интерливинг
+  // Кодирование RS и последующая обработка
   std::vector<uint8_t> coded;
   if (msg.size() == RS_DATA_LEN) {
     uint8_t rs_buf[RS_ENC_LEN];
-    rs255223::encode(msg.data(), rs_buf);          // кодируем блок
+    rs255223::encode(msg.data(), rs_buf);             // кодируем блок
     byte_interleaver::interleave(rs_buf, RS_ENC_LEN); // байтовый интерливинг
-    coded.assign(rs_buf, rs_buf + RS_ENC_LEN);
+
+    std::vector<uint8_t> conv;
+    conv_codec::encodeBits(rs_buf, RS_ENC_LEN, conv); // свёрточное кодирование
+    if (USE_BIT_INTERLEAVER)
+      bit_interleaver::interleave(conv.data(), conv.size()); // битовый интерливинг
+    lfsr_scramble(conv.data(), conv.size(), (uint16_t)id);   // скремблер
+    coded.swap(conv);
   } else {
-    coded = msg;                                   // без кодирования для других размеров
+    coded = msg;                                      // без кодирования для других размеров
   }
 
   FrameHeader hdr;


### PR DESCRIPTION
## Summary
- добавлены обёртки `encodeBits` и `viterbiDecode` в новой библиотеке `conv_codec`
- реализован битовый интерливинг и скремблирование в цепочке Tx/Rx
- README дополнен описанием новых функций и обновлённой цепочки обработки

## Testing
- `g++ -std=c++17 -I. tests/test_message_buffer.cpp message_buffer.cpp libs_includes.cpp -o test_message_buffer && ./test_message_buffer`
- `g++ -std=c++17 -I. -Ilibs tests/test_packet_splitter.cpp message_buffer.cpp libs_includes.cpp -o test_packet_splitter && ./test_packet_splitter`
- `g++ -std=c++17 -I. tests/test_text_converter.cpp message_buffer.cpp libs_includes.cpp -o test_text_converter && ./test_text_converter`
- `g++ -std=c++17 -I. tests/test_tx_module.cpp message_buffer.cpp tx_module.cpp libs_includes.cpp -o test_tx_module && ./test_tx_module`
- `g++ -std=c++17 -I. tests/test_full_flow.cpp message_buffer.cpp tx_module.cpp rx_module.cpp libs_includes.cpp -o test_full_flow && ./test_full_flow`


------
https://chatgpt.com/codex/tasks/task_e_68a8c71dd464833084a6d00942bbe6ba