### PR TITLE
Добавлены параметры блока PacketGatherer и паузы отправок

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@
 - `void sendBeacon()` — отправить служебный пакет-маяк.
 - `ChannelBank getBank() const`, `uint8_t getChannel() const`, `float getBandwidth() const`, `int getSpreadingFactor() const`, `int getCodingRate() const`, `int getPower() const`, `float getRxFrequency() const`, `float getTxFrequency() const` — получить текущие параметры.
   - `bool resetToDefaults()` — вернуть параметры радиомодуля к значениям по умолчанию.
-  - Значения параметров по умолчанию заданы в файле `default_settings.h`.
+  - Значения параметров по умолчанию (размер блока для `PacketGatherer`, пауза между отправками и т.д.) заданы в файле `default_settings.h`.
 
 ### SerialProgramCollector
 - `void resetBuffer()` — очистить буфер и начать новый сбор.
@@ -136,7 +136,7 @@ rs255223::decode -> PacketGatherer -> обработка сообщения
 - Настройка мощности и команда INFO для отображения текущих параметров.
 - Отправка служебного маяка для поиска устройств.
 - Конвертация UTF-8 текста в CP1251 для команды TX.
-- Файл `default_settings.h` с параметрами радиомодуля по умолчанию.
+- Файл `default_settings.h` с параметрами радиомодуля, размером блока `PacketGatherer` и паузой между отправками по умолчанию.
 - Базовые тесты для буфера сообщений, делителя пакетов и формирования кадров.
 
 ## Что осталось сделать

--- a/default_settings.h
+++ b/default_settings.h
@@ -10,11 +10,13 @@ namespace DefaultSettings {
   constexpr uint8_t BW_PRESET = 3;                // Индекс полосы
   constexpr uint8_t SF_PRESET = 2;                // Индекс фактора расширения
   constexpr uint8_t CR_PRESET = 0;                // Индекс коэффициента кодирования
-    constexpr bool DEBUG = true;                    // Флаг отладочного вывода
-    // Уровни журналирования для фильтрации сообщений
-    enum class LogLevel : uint8_t { ERROR = 0, WARN = 1, INFO = 2, DEBUG = 3 };
-    constexpr LogLevel LOG_LEVEL = LogLevel::INFO;   // Текущий уровень вывода
-  }
+  constexpr size_t GATHER_BLOCK_SIZE = 223;       // Размер блока для PacketGatherer
+  constexpr uint32_t SEND_PAUSE_MS = 0;           // Ожидание между отправками и приёмом (мс)
+  constexpr bool DEBUG = true;                    // Флаг отладочного вывода
+  // Уровни журналирования для фильтрации сообщений
+  enum class LogLevel : uint8_t { ERROR = 0, WARN = 1, INFO = 2, DEBUG = 3 };
+  constexpr LogLevel LOG_LEVEL = LogLevel::INFO;   // Текущий уровень вывода
+}
 
 #if !defined(LOG_MSG)
 #  if defined(ARDUINO)

--- a/rx_module.cpp
+++ b/rx_module.cpp
@@ -5,9 +5,10 @@
 #include "libs/conv_codec/conv_codec.h" // свёрточный кодер/декодер
 #include "libs/bit_interleaver/bit_interleaver.h" // битовый интерливинг
 #include "libs/scrambler/scrambler.h" // скремблер
+#include "default_settings.h"         // параметры по умолчанию
 #include <vector>
 
-static constexpr size_t RS_DATA_LEN = 223;     // длина блока данных RS
+static constexpr size_t RS_DATA_LEN = DefaultSettings::GATHER_BLOCK_SIZE; // длина блока данных RS
 static constexpr size_t RS_ENC_LEN = 255;      // длина закодированного блока
 static constexpr bool USE_BIT_INTERLEAVER = true; // включение битового интерливинга
 
@@ -31,7 +32,7 @@ static std::vector<uint8_t> removePilots(const uint8_t* data, size_t len) {
 }
 
 // Конструктор модуля приёма
-RxModule::RxModule() : gatherer_(PayloadMode::SMALL, RS_DATA_LEN) {}
+RxModule::RxModule() : gatherer_(PayloadMode::SMALL, DefaultSettings::GATHER_BLOCK_SIZE) {}
 
 // Передаём данные колбэку, если заголовок валиден
 void RxModule::onReceive(const uint8_t* data, size_t len) {

--- a/tx_module.cpp
+++ b/tx_module.cpp
@@ -11,7 +11,7 @@
 
 // Максимально допустимый размер кадра
 static constexpr size_t MAX_FRAME_SIZE = 255;      // максимально допустимый кадр
-static constexpr size_t RS_DATA_LEN = 223;         // длина блока данных RS
+static constexpr size_t RS_DATA_LEN = DefaultSettings::GATHER_BLOCK_SIZE; // длина блока данных RS
 static constexpr size_t RS_ENC_LEN = 255;         // длина закодированного блока
 static constexpr bool USE_BIT_INTERLEAVER = true; // включение битового интерливинга
 
@@ -36,7 +36,7 @@ TxModule::TxModule(IRadio& radio, const std::array<size_t,4>& capacities, Payloa
   : radio_(radio), buffers_{MessageBuffer(capacities[0]), MessageBuffer(capacities[1]),
                              MessageBuffer(capacities[2]), MessageBuffer(capacities[3])},
     splitter_(mode) {
-  last_send_ = std::chrono::steady_clock::now();
+  last_send_ = std::chrono::steady_clock::now() - std::chrono::milliseconds(pause_ms_);
 }
 
 // Смена режима пакета
@@ -84,7 +84,7 @@ void TxModule::loop() {
 
   // TODO: шифрование сообщения (не реализовано)
 
-  // Разбиваем сообщение на блоки по 223 байта перед RS-кодированием
+  // Разбиваем сообщение на блоки по RS_DATA_LEN байт перед RS-кодированием
   PacketSplitter rs_splitter(PayloadMode::SMALL, RS_DATA_LEN);
   size_t parts = (msg.size() + RS_DATA_LEN - 1) / RS_DATA_LEN;
   MessageBuffer tmp(parts);

--- a/tx_module.h
+++ b/tx_module.h
@@ -5,6 +5,7 @@
 #include "radio_interface.h"
 #include "message_buffer.h"
 #include "libs/packetizer/packet_splitter.h" // подключаем разделитель пакетов из каталога libs
+#include "default_settings.h"                  // параметры по умолчанию
 
 // Модуль передачи данных с поддержкой классов QoS
 class TxModule {
@@ -23,7 +24,7 @@ private:
   IRadio& radio_;
   std::array<MessageBuffer,4> buffers_;             // очереди сообщений по классам QoS
   PacketSplitter splitter_;
-  uint32_t pause_ms_ = 0;                           // пауза между пакетами
+  uint32_t pause_ms_ = DefaultSettings::SEND_PAUSE_MS; // пауза между пакетами
   std::chrono::steady_clock::time_point last_send_; // время последней отправки
 };
 


### PR DESCRIPTION
## Summary
- добавлен параметр `GATHER_BLOCK_SIZE` и задержка `SEND_PAUSE_MS` в `default_settings.h`
- TxModule использует `SEND_PAUSE_MS` и значение блока из настроек
- RxModule берёт размер блока из `default_settings.h`
- обновлён README

## Testing
- `g++ -std=c++17 tests/test_message_buffer.cpp message_buffer.cpp -I. -Ilibs -o test_message_buffer && ./test_message_buffer`
- `g++ -std=c++17 tests/test_packet_splitter.cpp message_buffer.cpp libs/packetizer/packet_splitter.cpp -I. -Ilibs -o test_packet_splitter && ./test_packet_splitter`
- `g++ -std=c++17 tests/test_text_converter.cpp libs/text_converter/text_converter.cpp -I. -Ilibs -o test_text_converter && ./test_text_converter`
- `g++ -std=c++17 tests/test_tx_module.cpp tx_module.cpp message_buffer.cpp libs/packetizer/packet_splitter.cpp libs/frame/frame_header.cpp libs/rs255223/rs255223.cpp libs/rs/rs.cpp libs/byte_interleaver/byte_interleaver.cpp libs/conv_codec/conv_codec.cpp libs/viterbi/viterbi.cpp libs/bit_interleaver/bit_interleaver.cpp libs/scrambler/scrambler.cpp -I. -Ilibs -o test_tx_module && ./test_tx_module`
- `g++ -std=c++17 tests/test_full_flow.cpp tx_module.cpp rx_module.cpp message_buffer.cpp libs/packetizer/packet_splitter.cpp libs/packetizer/packet_gatherer.cpp libs/frame/frame_header.cpp libs/rs255223/rs255223.cpp libs/rs/rs.cpp libs/byte_interleaver/byte_interleaver.cpp libs/conv_codec/conv_codec.cpp libs/viterbi/viterbi.cpp libs/bit_interleaver/bit_interleaver.cpp libs/scrambler/scrambler.cpp -I. -Ilibs -o test_full_flow && ./test_full_flow`


------
https://chatgpt.com/codex/tasks/task_e_68a8ce2662cc8330baf6d747d7b9c4dd