### PR TITLE
Rename STSR command to RSTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - `IRadio` описан в `radio_interface.h`.
 - `RadioSX1262` — конкретная реализация интерфейса на базе модуля SX1262.
 - `SerialProgramCollector` — библиотека для приёма строк по Serial и сборки их в один буфер (`libs/serial_program_collector/`).
-  - `serial_radio_control.ino` — пример настройки банков каналов, BW, SF, CR и мощности через Serial, вывода текущих параметров и отправки тестовых пакетов через `TxModule`, включая команды `TXL` для больших сообщений, `STS <n>` для просмотра журнала и `STSR <n>` для просмотра содержимого `ReceivedBuffer`.
+  - `serial_radio_control.ino` — пример настройки банков каналов, BW, SF, CR и мощности через Serial, вывода текущих параметров и отправки тестовых пакетов через `TxModule`, включая команды `TXL` для больших сообщений, `STS <n>` для просмотра журнала и `RSTS <n>` для просмотра содержимого `ReceivedBuffer`.
 - `TextConverter` — библиотека (`libs/text_converter/`) для преобразования UTF-8 текста в байты CP1251, используемая командой `TX`.
 - `rs255223` — библиотека (`libs/rs255223/`) с обёртками `encode()` и `decode()` для кода Рида–Соломона RS(255,223).
 - `byte_interleaver` — библиотека (`libs/byte_interleaver/`) с функциями `interleave()` и `deinterleave()` для байтового перемежения.

--- a/serial_radio_control.ino
+++ b/serial_radio_control.ino
@@ -29,7 +29,7 @@ void setup() {
   radio.setReceiveCallback([&](const uint8_t* d, size_t l){  // привязка приёма
     rx.onReceive(d, l);
   });
-  Serial.println("Команды: BF <полоса>, SF <фактор>, CR <код>, BANK <e|w|t>, CH <0-9>, PW <0-9>, TX <строка>, TXL <размер>, BCN, INFO, STS <n>, STSR <n>");
+  Serial.println("Команды: BF <полоса>, SF <фактор>, CR <код>, BANK <e|w|t>, CH <0-9>, PW <0-9>, TX <строка>, TXL <размер>, BCN, INFO, STS <n>, RSTS <n>");
 }
 
 void loop() {
@@ -111,11 +111,11 @@ void loop() {
         for (const auto& s : logs) {
           Serial.println(s.c_str());
         }
-      } else if (line.startsWith("STSR")) {
+      } else if (line.startsWith("RSTS")) {
         int cnt = line.length() > 4 ? line.substring(5).toInt() : 10; // ограничение выводимых имён
         if (cnt <= 0) cnt = 10;                                       // значение по умолчанию
-        auto names = recvBuf.list(cnt);                               // получаем список имён
-        for (const auto& n : names) {                                  
+        auto names = recvBuf.list(cnt);                               // получаем список имён из буфера
+        for (const auto& n : names) {
           Serial.println(n.c_str());
         }
       } else if (line.startsWith("TX ")) {


### PR DESCRIPTION
## Summary
- заменить команду **STSR** на **RSTS** для вывода списка полученных сообщений
- обновить документацию с новым названием команды

## Testing
- `g++ -I. -I.. tests/test_processing_without_send.cpp tx_module.cpp rx_module.cpp message_buffer.cpp libs_includes.cpp -std=c++17 && ./a.out`


------
https://chatgpt.com/codex/tasks/task_e_68a97ca2d6048330a6b6994082ff8071