### PR TITLE
Fix header duplication for ChannelBank and default settings

### DIFF
--- a/channel_bank.h
+++ b/channel_bank.h
@@ -1,5 +1,9 @@
 #pragma once
+#ifndef CHANNEL_BANK_H
+#define CHANNEL_BANK_H // защита от повторного включения
 
 // Перечисление банков каналов
 enum class ChannelBank { EAST, WEST, TEST };
+
+#endif // CHANNEL_BANK_H
 

--- a/default_settings.h
+++ b/default_settings.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifndef DEFAULT_SETTINGS_H
+#define DEFAULT_SETTINGS_H // защита от повторного включения
+
 #include <cstdint>
 #include <array>
 #include "channel_bank.h" // Банк каналов
@@ -103,5 +106,7 @@ namespace LogDetail {
 #  define LOG_WARN_VAL(prefix, val)  LOG_MSG_VAL(DefaultSettings::LogLevel::WARN,  prefix, val)
 #  define LOG_INFO_VAL(prefix, val)  LOG_MSG_VAL(DefaultSettings::LogLevel::INFO,  prefix, val)
 #  define DEBUG_LOG_VAL(prefix, val) LOG_MSG_VAL(DefaultSettings::LogLevel::DEBUG, prefix, val)
-#endif
+#endif // !defined(LOG_MSG)
+
+#endif // DEFAULT_SETTINGS_H
 


### PR DESCRIPTION
## Summary
- Добавлены include guard в `channel_bank.h` и `default_settings.h`, что устраняет повторные определения при множественном подключении

## Testing
- `g++ -I. tests/test_enct.cpp libs_includes.cpp message_buffer.cpp -std=c++17 && ./a.out`
- `g++ -I. tests/test_processing_without_send.cpp tx_module.cpp rx_module.cpp message_buffer.cpp libs_includes.cpp -std=c++17 && ./a.out`


------
https://chatgpt.com/codex/tasks/task_e_68a990db840c8330863be45800fd9462