### PR TITLE
Исправление получения SNR/RSSI и добавление randomByte

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@
 - `void setReceiveCallback(IRadio::RxCallback cb)` — регистрация обработчика приёма.
 - `float getLastSnr() const` — получить SNR последнего принятого пакета.
 - `float getLastRssi() const` — получить RSSI последнего принятого пакета.
+- `uint8_t randomByte()` — получить случайный байт от радиомодуля.
 - `bool setBank(ChannelBank bank)` — выбрать банк каналов (`EAST`, `WEST`, `TEST`).
 - `bool setChannel(uint8_t ch)` — выбрать номер канала 0…9 и установить частоту приёма.
 - `bool setBandwidth(float bw)` — задать ширину полосы в кГц.
@@ -192,6 +193,7 @@ rs255223::decode -> PacketGatherer -> обработка сообщения
 - Реализована команда PI для пинга с выводом RSSI и SNR.
 - Добавлена команда SEAR для последовательного пинга всех каналов с выводом RSSI и SNR.
 - Добавлены методы `getLastRssi()` и `getLastSnr()` в `RadioSX1262`.
+- Добавлен метод `randomByte()` в `RadioSX1262`.
 - Введена константа `PING_WAIT_MS`, задающая время ожидания ответа на пинг.
 - Пример `serial_radio_control.ino` использует 160-слотовые очереди, что позволяет хранить несколько сообщений по 5000 байт.
 - Файл `default_settings.h` с параметрами радиомодуля, размером блока `PacketGatherer`,

--- a/radio_sx1262.cpp
+++ b/radio_sx1262.cpp
@@ -64,6 +64,9 @@ float RadioSX1262::getLastSnr() const { return lastSnr_; }
 // Получить RSSI последнего принятого пакета
 float RadioSX1262::getLastRssi() const { return lastRssi_; }
 
+// Получить случайный байт из встроенного генератора
+uint8_t RadioSX1262::randomByte() { return radio_.randomByte(); }
+
 bool RadioSX1262::setBank(ChannelBank bank) {
   bank_ = bank;
   channel_ = 0;
@@ -168,8 +171,8 @@ void RadioSX1262::loop() {
   std::array<uint8_t, 256> buf;            // статический буфер на стеке
   int state = radio_.readData(buf.data(), len);
   if (state == RADIOLIB_ERR_NONE) {
-    lastSnr_ = radio_.getPacketSNR();       // сохраняем SNR
-    lastRssi_ = radio_.getPacketRSSI();     // сохраняем RSSI
+    lastSnr_ = radio_.getSNR();             // сохраняем SNR
+    lastRssi_ = radio_.getRSSI();           // сохраняем RSSI
     if (rx_cb_) {
       rx_cb_(buf.data(), len);              // передаём данные пользователю
     }
@@ -180,8 +183,8 @@ void RadioSX1262::loop() {
 
 void RadioSX1262::sendBeacon() {
   uint8_t beacon[15]{0};                  // буфер маяка
-  beacon[1] = radio_.randomByte();        // случайный байт 1
-  beacon[2] = radio_.randomByte();        // случайный байт 2
+  beacon[1] = randomByte();               // случайный байт 1
+  beacon[2] = randomByte();               // случайный байт 2
   beacon[0] = beacon[1] ^ beacon[2];      // идентификатор = XOR
   const char text[6] = {'B','E','A','C','O','N'}; // надпись "BEACON"
   memcpy(&beacon[9], text, 6);            // вставка текста

--- a/radio_sx1262.h
+++ b/radio_sx1262.h
@@ -22,6 +22,8 @@ public:
   // Получение параметров последнего принятого пакета
   float getLastSnr() const;  // последний SNR
   float getLastRssi() const; // последний RSSI
+  // Получить случайный байт
+  uint8_t randomByte();
   // Выбор банка каналов (EAST, WEST, TEST)
   bool setBank(ChannelBank bank);
   // Выбор канала 0-9 из текущего банка


### PR DESCRIPTION
## Summary
- заменить вызовы `getPacketSNR/getPacketRSSI` на `getSNR/getRSSI`
- добавить метод `randomByte()` в `RadioSX1262` и обновить README

## Testing
- `g++ -I. tests/test_enct.cpp libs/crypto/aes_ccm.cpp libs/mbedtls/aes.c libs/mbedtls/ccm.c -std=c++17 && ./a.out`
- `g++ -I. tests/test_message_buffer.cpp message_buffer.cpp -std=c++17 && ./a.out`
- `g++ -I. tests/test_received_buffer.cpp libs/received_buffer/received_buffer.cpp -std=c++17 && ./a.out`
- `g++ -I. tests/test_full_flow.cpp tx_module.cpp rx_module.cpp message_buffer.cpp libs_includes.cpp -std=c++17 -pthread && ./a.out`
- `g++ -I. -Ilibs tests/test_packet_splitter.cpp message_buffer.cpp libs_includes.cpp -std=c++17 && ./a.out`
- `g++ -I. tests/test_text_converter.cpp libs/text_converter/text_converter.cpp -std=c++17 && ./a.out`
- `g++ -I. -Ilibs tests/test_large_packet_capacity.cpp message_buffer.cpp libs_includes.cpp -std=c++17 && ./a.out`
- `g++ -I. tests/test_processing_without_send.cpp tx_module.cpp rx_module.cpp message_buffer.cpp libs_includes.cpp -std=c++17 && ./a.out`
- `g++ -I. tests/test_tx_module.cpp tx_module.cpp message_buffer.cpp libs_includes.cpp -std=c++17 && ./a.out`


------
https://chatgpt.com/codex/tasks/task_e_68a99eb2f0e08330b5f648ecee124599