### PR TITLE
Семантическая навигация для веб-интерфейса

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -10,13 +10,15 @@
   <nav id="main-nav">
     <!-- Кнопка отображения пунктов меню на узких экранах -->
     <button id="menu-toggle">☰</button>
-    <!-- Группа ссылок навигации -->
-    <div id="nav-links">
-      <button class="tab-btn" data-tab="chat">Chat</button>
-      <button class="tab-btn" data-tab="channels">Channels/Ping</button>
-      <button class="tab-btn" data-tab="settings">Settings</button>
-      <a href="#" id="security-link" data-tab="security">Security</a>
-    </div>
+    <!-- Основные ссылки навигации -->
+    <nav aria-label="Главное меню">
+      <ul id="nav-links">
+        <li><a class="tab-btn" data-tab="chat" href="#chat">Chat</a></li>
+        <li><a class="tab-btn" data-tab="channels" href="#channels">Channels/Ping</a></li>
+        <li><a class="tab-btn" data-tab="settings" href="#settings">Settings</a></li>
+        <li><a id="security-link" data-tab="security" href="#security">Security</a></li>
+      </ul>
+    </nav>
   </nav>
 
   <!-- Области содержимого для каждой вкладки -->

--- a/web/style.css
+++ b/web/style.css
@@ -17,11 +17,20 @@ nav {
   margin-bottom: 20px;
 }
 
-/* Контейнер ссылок навигации */
-#nav-links {
+/* Список ссылок навигации */
+nav ul {
   display: flex;
   gap: 10px;
   flex: 1;
+  list-style: none; /* убираем маркеры списка */
+  margin: 0; /* убираем внешние отступы */
+  padding: 0; /* убираем внутренние отступы */
+}
+
+/* Последний пункт списка — ссылка безопасности */
+nav li:last-child {
+  margin-left: auto; /* отделяем ссылку безопасности справа */
+  align-self: center;
 }
 
 /* Кнопка вызова мобильного меню */
@@ -44,11 +53,6 @@ body.dark nav {
   display: block; /* показываем выбранную вкладку */
 }
 
-#security-link {
-  margin-left: auto; /* отделяем ссылку безопасности справа */
-  align-self: center;
-}
-
 /* Адаптация меню под мобильные устройства */
 @media (max-width: 600px) {
   nav {
@@ -58,16 +62,16 @@ body.dark nav {
   #menu-toggle {
     display: block; /* показываем кнопку меню */
   }
-  #nav-links {
+  nav ul {
     display: none; /* скрываем ссылки пока меню закрыто */
     flex-direction: column;
     width: 100%;
     gap: 5px;
   }
-  nav.open #nav-links {
+  nav.open ul {
     display: flex; /* показываем при открытии */
   }
-  #security-link {
+  nav li:last-child {
     margin-left: 0; /* убираем отступ справа */
   }
 }


### PR DESCRIPTION
## Summary
- заменён блок ссылок на семантический список внутри `nav`
- добавлены атрибуты `aria-label` и новые стили для `nav ul` и `nav li`

## Testing
- `for f in tests/*.cpp; do echo "Compiling $f"; g++ -std=c++17 -I. "$f" && ./a.out; done` *(failed: undefined reference to `encrypt_ccm`)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cd1faa788330805bb846107f386d