### PR TITLE
style: группировка include по образцу sat_radv0.01a

### DIFF
--- a/serial_radio_control.ino
+++ b/serial_radio_control.ino
@@ -1,18 +1,24 @@
 #include <Arduino.h>
 #include <array>
 #include <vector>
+#include <cstring> // для strlen
+
+// --- Радио и модули ---
 #include "radio_sx1262.h"
 #include "tx_module.h"
-#include "rx_module.h"                             // модуль приёма
+#include "rx_module.h" // модуль приёма
 #include "default_settings.h"
-#include "libs/text_converter/text_converter.h" // конвертер UTF-8 -> CP1251
-#include "libs/simple_logger/simple_logger.h"    // журнал статусов
-#include "libs/received_buffer/received_buffer.h"// буфер принятых сообщений
+
+// --- Вспомогательные библиотеки ---
+#include "libs/text_converter/text_converter.h"   // конвертер UTF-8 -> CP1251
+#include "libs/simple_logger/simple_logger.h"     // журнал статусов
+#include "libs/received_buffer/received_buffer.h" // буфер принятых сообщений
 #include "libs/crypto/aes_ccm.h"                  // AES-CCM шифрование
-#include <cstring>                                 // для strlen
-#include <WiFi.h>                                   // работа с Wi-Fi
-#include <WebServer.h>                              // встроенный HTTP-сервер
-#include "web/web_content.h"                        // встроенные файлы веб-интерфейса
+
+// --- Сеть и веб-интерфейс ---
+#include <WiFi.h>        // работа с Wi-Fi
+#include <WebServer.h>   // встроенный HTTP-сервер
+#include "web/web_content.h" // встроенные файлы веб-интерфейса
 
 // Пример управления радиомодулем через Serial c использованием абстрактного слоя
 RadioSX1262 radio;


### PR DESCRIPTION
## Summary
- Сгруппированы подключаемые заголовки в `serial_radio_control.ino` по тематическим блокам.

## Testing
- `g++ -I. tests/test_enct.cpp libs_includes.cpp message_buffer.cpp -std=c++17 && ./a.out`


------
https://chatgpt.com/codex/tasks/task_e_68a9f4a090f4833083eeb283214cb344