### PR TITLE
Предотвращение вывода HTML в чате

### DIFF
--- a/web/script.js
+++ b/web/script.js
@@ -203,6 +203,11 @@ async function deviceFetch(cmd, params = {}, timeoutMs = 4000) {
       clearTimeout(id);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const text = await res.text();
+      // Если устройство не ответило и сервер вернул HTML-страницу,
+      // помечаем такой ответ как ошибку, чтобы не выводить разметку в чат.
+      if (/<!DOCTYPE|<html/i.test(text)) {
+        throw new Error("HTML response");
+      }
       return { ok: true, text, url };
     } catch (e) {
       lastErr = e;


### PR DESCRIPTION
## Summary
- Добавлена проверка HTML-ответов устройства, чтобы не засорять чат разметкой

## Testing
- `g++ -I. tests/test_enct.cpp libs_includes.cpp message_buffer.cpp -std=c++17 && ./a.out`

------
https://chatgpt.com/codex/tasks/task_e_68aaeedabf1c83308358dcaf63a35082