### PR TITLE
Добавлены поля TX/RX/Scan в таблицу каналов

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -52,7 +52,8 @@
       <div class="table-wrap pretty">
         <table id="channelsTable">
           <thead>
-            <tr><th>#</th><th>CH</th><th>F,MHz</th><th>BW</th><th>SF</th><th>CR</th><th>PW</th><th>RSSI</th><th>SNR</th><th>ST</th></tr>
+            <!-- Добавлены столбцы TX, RX и Scan для отображения частот и результата сканирования -->
+            <tr><th>#</th><th>CH</th><th>TX</th><th>RX</th><th>BW</th><th>SF</th><th>CR</th><th>PW</th><th>RSSI</th><th>SNR</th><th>ST</th><th>Scan</th></tr>
           </thead>
           <tbody></tbody>
         </table>


### PR DESCRIPTION
## Summary
- расширен заголовок таблицы каналов: добавлены столбцы TX, RX и Scan
- обновлён фронтенд: объекты каналов хранят частоты tx/rx и результат сканирования, переработан парсер CHLIST и экспорт CSV

## Testing
- `for f in tests/*.cpp; do echo "== $f =="; g++ -std=c++17 -I. "$f" libs_includes.cpp -o /tmp/test && /tmp/test; done` *(linker errors: undefined reference to MessageBuffer, RxModule, TxModule)*

------
https://chatgpt.com/codex/tasks/task_e_68ac15739540833089f74ad75cff67fd