### PR TITLE
Добавлен вывод TX/RX частот в списке каналов

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@
 - `ChannelBank getBank() const`, `uint8_t getChannel() const`, `uint16_t getBankSize() const`, `float getBandwidth() const`, `int getSpreadingFactor() const`, `int getCodingRate() const`, `int getPower() const`, `float getRxFrequency() const`, `float getTxFrequency() const` — получить текущие параметры.
 - `static uint16_t bankSize(ChannelBank bank)` — количество каналов в указанном банке.
 - `static float bankRx(ChannelBank bank, uint16_t ch)` — частота приёма канала в банке.
+ - `static float bankTx(ChannelBank bank, uint16_t ch)` — частота передачи канала в банке.
   - `bool resetToDefaults()` — вернуть параметры радиомодуля к значениям по умолчанию.
   - Значения параметров по умолчанию (размер блока для `PacketGatherer`, пауза между отправками и т.д.) заданы в файле `default_settings.h`.
 

--- a/radio_sx1262.cpp
+++ b/radio_sx1262.cpp
@@ -83,6 +83,11 @@ float RadioSX1262::bankRx(ChannelBank bank, uint16_t ch) {
   return fRX_bank_[static_cast<int>(bank)][ch];
 }
 
+float RadioSX1262::bankTx(ChannelBank bank, uint16_t ch) {
+  // Возвращаем частоту передачи для канала в выбранном банке
+  return fTX_bank_[static_cast<int>(bank)][ch];
+}
+
 const int8_t RadioSX1262::Pwr_[10] = {-5, -2, 1, 4, 7, 10, 13, 16, 19, 22};
 const float RadioSX1262::BW_[5] = {7.81, 10.42, 15.63, 20.83, 31.25};
 const int8_t RadioSX1262::SF_[8] = {5, 6, 7, 8, 9, 10, 11, 12};

--- a/radio_sx1262.h
+++ b/radio_sx1262.h
@@ -45,6 +45,8 @@ public:
   static uint16_t bankSize(ChannelBank bank);
   // Получить частоту приёма для канала в указанном банке
   static float bankRx(ChannelBank bank, uint16_t ch);
+  // Получить частоту передачи для канала в указанном банке
+  static float bankTx(ChannelBank bank, uint16_t ch);
   float getBandwidth() const { return BW_[bw_preset_]; }
   int getSpreadingFactor() const { return SF_[sf_preset_]; }
   int getCodingRate() const { return CR_[cr_preset_]; }

--- a/serial_radio_control.ino
+++ b/serial_radio_control.ino
@@ -179,13 +179,16 @@ String cmdSear() {
 
 // Список частот для выбранного банка в формате CSV
 String cmdChlist(ChannelBank bank) {
-  String out = "ch,freq,bw,sf,cr,pw,rssi,snr,st\n";
+  // Формируем CSV в формате ch,tx,rx,rssi,snr,st,scan
+  String out = "ch,tx,rx,rssi,snr,st,scan\n";
   uint16_t n = RadioSX1262::bankSize(bank);
   for (uint16_t i = 0; i < n; ++i) {
-    out += String(i);
+    out += String(i);                               // номер канала
     out += ',';
-    out += String(RadioSX1262::bankRx(bank, i), 3);
-    out += ",0,0,0,0,0,0,\n";
+    out += String(RadioSX1262::bankTx(bank, i), 3); // частота передачи
+    out += ',';
+    out += String(RadioSX1262::bankRx(bank, i), 3); // частота приёма
+    out += ",0,0,,\n";                             // пустые поля rssi/snr/st/scan
   }
   return out;
 }


### PR DESCRIPTION
## Summary
- добавлена функция `bankTx` в `RadioSX1262`
- команда `CHLIST` теперь возвращает CSV с TX/RX
- README дополнен описанием новой функции

## Testing
- `g++ -I. tests/test_enct.cpp libs/crypto/aes_ccm.cpp libs/mbedtls/aes.c libs/mbedtls/ccm.c -std=c++17 && ./a.out`

------
https://chatgpt.com/codex/tasks/task_e_68ac266aadcc83308bb311a6b9bbbaf7