### PR TITLE
Исправлено отображение списка каналов

### DIFF
--- a/web/script.js
+++ b/web/script.js
@@ -307,6 +307,10 @@ async function refreshChannels() {
     if (r && r.ok && r.text) {
       // ожидаем строки CSV, разбираем их
       channels = parseChannels(r.text);
+      // если устройство ответило, но список пуст, подставляем заглушку
+      if (!channels.length) {
+        mockChannels();
+      }
     } else if (!channels.length) {
       mockChannels();
     }


### PR DESCRIPTION
## Summary
- гарантировано подставляем заглушку каналов, если устройство не вернуло список

## Testing
- `g++ -I. tests/test_message_buffer.cpp message_buffer.cpp libs_includes.cpp -std=c++17 && ./a.out`
- `g++ -I. tests/test_enct.cpp message_buffer.cpp libs_includes.cpp -std=c++17 && ./a.out`
- `g++ -I. tests/test_packet_splitter.cpp message_buffer.cpp libs_includes.cpp -std=c++17 && ./a.out` *(failed: packetizer/packet_splitter.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2c16832083309f6d41ba3bf62914