### PR TITLE
Implement raw ping handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@
 ### RadioSX1262
   - `bool begin()` — инициализация радиомодуля с автоматическим возвратом параметров к значениям по умолчанию.
 - `void send(const uint8_t* data, size_t len)` — отправка пакета.
+- `bool ping(const uint8_t* data, size_t len, uint8_t* response, size_t responseCapacity, size_t& receivedLen, uint32_t timeoutUs, uint32_t& elapsedUs)` — отправка служебного пакета и ожидание эха с возвратом параметров приёма.
 - `void loop()` — обработка готовности пакета и вызов колбэка в основном цикле.
 - `void setReceiveCallback(IRadio::RxCallback cb)` — регистрация обработчика приёма.
 - `float getLastSnr() const` — получить SNR последнего принятого пакета.

--- a/radio_sx1262.h
+++ b/radio_sx1262.h
@@ -13,6 +13,11 @@ public:
   bool begin();
   // Отправка данных
   void send(const uint8_t* data, size_t len) override;
+  // Выполнение пинга с ожиданием эха
+  bool ping(const uint8_t* data, size_t len,
+            uint8_t* response, size_t responseCapacity,
+            size_t& receivedLen, uint32_t timeoutUs,
+            uint32_t& elapsedUs);
   // Отправка служебного маяка
   void sendBeacon();
   // Обработка готовности пакета в основном цикле


### PR DESCRIPTION
## Summary
- добавлен метод `RadioSX1262::ping`, выполняющий прямую передачу пинг-пакета и ожидание эха с сохранением RSSI/SNR
- обновлены команды `PI` и `SEAR`, теперь они вызывают новый метод радиомодуля и работают с пятибайтовым пакетом без очередей `TxModule`
- задокументирован новый API `ping` в разделе `RadioSX1262`

## Testing
- `g++ -I. tests/test_enct.cpp libs_includes.cpp message_buffer.cpp message_buffer.h tx_module.cpp rx_module.cpp radio_sx1262.cpp -std=c++17 -o test_enct && ./test_enct` *(ошибка: отсутствует библиотека RadioLib для сборки вне Arduino)*

------
https://chatgpt.com/codex/tasks/task_e_68ccbfc49c988330abc16b31720a1d17