### PR TITLE
Исправление ошибок компиляции Arduino

### DIFF
--- a/libs/crypto/curve25519_donna.cpp
+++ b/libs/crypto/curve25519_donna.cpp
@@ -601,24 +601,28 @@ fcontract(u8 *output, limb *input_limbs) {
   input[7] <<= 3;
   input[8] <<= 4;
   input[9] <<= 6;
-#define F(i, s) \
-  output[s+0] |=  input[i] & 0xff; \
-  output[s+1]  = (input[i] >> 8) & 0xff; \
-  output[s+2]  = (input[i] >> 16) & 0xff; \
-  output[s+3]  = (input[i] >> 24) & 0xff;
+
+  // Локальная лямбда заменяет макрос F, чтобы не конфликтовать с Arduino-хедером.
+  const auto append_limb = [&](int idx, int offset) {
+    output[offset + 0] = static_cast<u8>(output[offset + 0] |
+                                         static_cast<u8>(input[idx] & 0xff));
+    output[offset + 1] = static_cast<u8>((input[idx] >> 8) & 0xff);
+    output[offset + 2] = static_cast<u8>((input[idx] >> 16) & 0xff);
+    output[offset + 3] = static_cast<u8>((input[idx] >> 24) & 0xff);
+  };
+
   output[0] = 0;
   output[16] = 0;
-  F(0,0);
-  F(1,3);
-  F(2,6);
-  F(3,9);
-  F(4,12);
-  F(5,16);
-  F(6,19);
-  F(7,22);
-  F(8,25);
-  F(9,28);
-#undef F
+  append_limb(0, 0);
+  append_limb(1, 3);
+  append_limb(2, 6);
+  append_limb(3, 9);
+  append_limb(4, 12);
+  append_limb(5, 16);
+  append_limb(6, 19);
+  append_limb(7, 22);
+  append_limb(8, 25);
+  append_limb(9, 28);
 }
 
 /* Input: Q, Q', Q-Q'

--- a/libs/frame/frame_header.h
+++ b/libs/frame/frame_header.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef LIBS_FRAME_FRAME_HEADER_H
+#define LIBS_FRAME_FRAME_HEADER_H
 #include <cstddef>
 #include <cstdint>
 #include <array>
@@ -28,3 +30,5 @@ struct FrameHeader {
   // Проверка контрольной суммы кадра
   bool checkFrameCrc(const uint8_t* payload, size_t payload_len) const;
 };
+
+#endif // LIBS_FRAME_FRAME_HEADER_H

--- a/libs/scrambler/scrambler.h
+++ b/libs/scrambler/scrambler.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef LIBS_SCRAMBLER_SCRAMBLER_H
+#define LIBS_SCRAMBLER_SCRAMBLER_H
 #include <cstddef>
 #include <cstdint>
 
@@ -15,3 +17,4 @@ inline void descramble(uint8_t* data, std::size_t len, uint16_t seed = 0xACE1) {
 
 } // namespace scrambler
 
+#endif // LIBS_SCRAMBLER_SCRAMBLER_H


### PR DESCRIPTION
## Summary
- заменил макрос `F` в реализации Curve25519 на локальную лямбду, исключив конфликт с `Arduino.h`
- добавил include-guard'ы в `frame_header.h` и `scrambler.h`, чтобы заголовки не подключались повторно при разных путях

## Testing
- not run (Arduino toolchain недоступен в контейнере)


------
https://chatgpt.com/codex/tasks/task_e_68ceddbdac648330b43701a1b47be55d