### PR TITLE
Fix JSON escape universal sequence

### DIFF
--- a/serial_radio_control.ino
+++ b/serial_radio_control.ino
@@ -120,7 +120,7 @@ String jsonEscape(const String& value) {
       default:
         if (static_cast<unsigned char>(c) < 0x20) {
           char buf[7];
-          std::snprintf(buf, sizeof(buf), "\\\u%04X", static_cast<unsigned>(static_cast<unsigned char>(c)));
+          std::snprintf(buf, sizeof(buf), "\\u%04X", static_cast<unsigned>(static_cast<unsigned char>(c)));
           out += buf;
         } else {
           out += c;


### PR DESCRIPTION
## Summary
- исправлено формирование escape-последовательности для управляющих символов в JSON, чтобы строка `\uXXXX` собиралась корректно

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf0846adec8330ab72f7f6dc0a123b