### PR TITLE
Оптимизация обработки ACK в TxModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@
 - `bool dropLast()` — удалить последнее сообщение (используется для отката).
 - `bool hasPending() const` — проверяет наличие сообщений.
 - `bool pop(uint32_t& id, std::vector<uint8_t>& out)` — извлекает сообщение и его идентификатор.
+- `const std::vector<uint8_t>* peek(uint32_t& id) const` — получить указатель на данные первого сообщения без извлечения.
 
 ### ReceivedBuffer
 - `std::string pushRaw(uint32_t id, uint32_t part, const uint8_t* data, size_t len)` — сохранить сырой пакет и получить имя вида `R-000000|номер`.

--- a/message_buffer.cpp
+++ b/message_buffer.cpp
@@ -55,3 +55,12 @@ bool MessageBuffer::pop(uint32_t& id, std::vector<uint8_t>& out) {
   DEBUG_LOG_VAL("MessageBuffer: извлечён id=", id);
   return true;
 }
+
+const std::vector<uint8_t>* MessageBuffer::peek(uint32_t& id) const {
+  if (q_.empty()) {                              // очередь пуста
+    DEBUG_LOG("MessageBuffer: просмотр пустой очереди");
+    return nullptr;
+  }
+  id = q_.front().first;
+  return &q_.front().second;                    // возвращаем указатель на данные без копирования
+}

--- a/message_buffer.h
+++ b/message_buffer.h
@@ -22,6 +22,8 @@ public:
   bool hasPending() const;
   // Извлекает первое сообщение из очереди, возвращает ID и данные
   bool pop(uint32_t& id, std::vector<uint8_t>& out);
+  // Позволяет заглянуть в начало очереди без извлечения
+  const std::vector<uint8_t>* peek(uint32_t& id) const;
 private:
   uint32_t next_id_ = 1;                                       // следующий идентификатор
   size_t capacity_;                                            // максимальное количество сообщений

--- a/tx_module.h
+++ b/tx_module.h
@@ -5,6 +5,7 @@
 #include <deque>
 #include <optional>
 #include <vector>
+#include <string>
 #include "radio_interface.h"
 #include "message_buffer.h"
 #include "libs/packetizer/packet_splitter.h" // подключаем разделитель пакетов из каталога libs
@@ -44,10 +45,13 @@ private:
     uint8_t qos = 0;                         // очередь QoS
     uint8_t attempts_left = 0;               // оставшиеся повторы
     bool expect_ack = false;                 // требуется ли подтверждение
+    std::string packet_tag;                  // идентификатор пакета для группировки частей
   };
 
   bool transmit(const PendingMessage& message);
   static bool isAckPayload(const std::vector<uint8_t>& data);
+  static std::string extractPacketTag(const std::vector<uint8_t>& data);
+  void archiveFollowingParts(uint8_t qos, const std::string& tag);
   void scheduleFromArchive();
   void onSendSuccess();
 


### PR DESCRIPTION
## Summary
- добавлен метод `MessageBuffer::peek`, позволяющий заглянуть в начало очереди без удаления элемента
- доработан `TxModule`: по тайм-ауту ACK весь оставшийся пакет переносится в архив, а части группируются по тегу
- расширен модульный тест `test_tx_module.cpp`, чтобы подтвердить новую логику повторов и архивации

## Testing
- `g++ -I. tests/test_tx_module.cpp tx_module.cpp message_buffer.cpp libs_includes.cpp -std=c++17 -o test_tx_module && ./test_tx_module`


------
https://chatgpt.com/codex/tasks/task_e_68cf87b47fbc83309d820785c487f28f