### PR TITLE
Добавлен переключатель ACK в настройках

### DIFF
--- a/web/web_content.h
+++ b/web/web_content.h
@@ -192,7 +192,10 @@ const char INDEX_HTML[] PROGMEM = R"~~~(
           </select>
         </label>
         <div class="settings-toggle" id="ackSettingControl">
-          <div class="field-label">ACK (подтверждения)</div>
+          <label class="chip switch">
+            <input type="checkbox" id="ACK" />
+            <span>ACK (подтверждения)</span>
+          </label>
           <div id="ackSettingHint" class="field-hint">Состояние не загружено.</div>
         </div>
         <label>ACK повторы


### PR DESCRIPTION
## Summary
- заменить статический текст управления ACK в настройках на переключатель с чекбоксом
- сохранить существующий класс `chip switch`, чтобы веб-интерфейс применял готовые стили
- убедиться, что обработчик изменения чекбокса вызывает `setAck`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d03a026b4c83308c8b671947bb4ebf