### PR TITLE
Объединение входящих сообщений с окном чата

### DIFF
--- a/web/script.js
+++ b/web/script.js
@@ -1367,7 +1367,6 @@ function setRecvAuto(enabled, opts) {
   }
 }
 async function refreshReceivedList(opts) {
-  if (!UI.els.recvList) return;
   const options = opts || {};
   const manual = options.manual === true;
   if (manual) status("→ RSTS");
@@ -1549,58 +1548,62 @@ function parseReceivedResponse(raw) {
                 .map((name) => ({ name, type: /^GO-/i.test(name) ? "ready" : "raw", text: "", hex: "", len: 0 }));
 }
 function renderReceivedList(items) {
-  if (!UI.els.recvList) return;
-  UI.els.recvList.innerHTML = "";
+  const hasList = !!UI.els.recvList;
+  if (hasList) UI.els.recvList.innerHTML = "";
   const prev = UI.state.receivedKnown instanceof Set ? UI.state.receivedKnown : new Set();
   const next = new Set();
-  const frag = document.createDocumentFragment();
+  const frag = hasList ? document.createDocumentFragment() : null;
   const list = Array.isArray(items) ? items : [];
   list.forEach((entry) => {
     const name = entry && entry.name ? String(entry.name).trim() : "";
     if (name) next.add(name);
-    const li = document.createElement("li");
-    li.classList.add("received-type-" + (entry && entry.type ? entry.type : "ready"));
-    const body = document.createElement("div");
-    body.className = "received-body";
-    const textNode = document.createElement("div");
-    const textValue = resolveReceivedText(entry);
-    textNode.className = "received-text" + (textValue ? "" : " empty");
-    textNode.textContent = textValue || "Без текста";
-    body.appendChild(textNode);
-    const meta = document.createElement("div");
-    meta.className = "received-meta";
-    const nameNode = document.createElement("span");
-    nameNode.className = "received-name";
-    nameNode.textContent = name || "—";
-    meta.appendChild(nameNode);
-    const lenValue = getReceivedLength(entry);
-    if (lenValue && lenValue > 0) {
-      const lenNode = document.createElement("span");
-      lenNode.className = "received-length";
-      lenNode.textContent = lenValue + " байт";
-      meta.appendChild(lenNode);
-    }
-    body.appendChild(meta);
-    li.appendChild(body);
-    const actions = document.createElement("div");
-    actions.className = "received-actions";
-    const copyBtn = document.createElement("button");
-    copyBtn.type = "button";
-    copyBtn.className = "icon-btn ghost";
-    copyBtn.textContent = "⧉";
-    copyBtn.title = "Скопировать имя";
-    copyBtn.addEventListener("click", () => copyReceivedName(name));
-    actions.appendChild(copyBtn);
-    li.appendChild(actions);
     const isNew = name && !prev.has(name);
-    if (isNew) {
-      li.classList.add("fresh");
-      setTimeout(() => li.classList.remove("fresh"), 1600);
+    if (hasList && frag) {
+      const li = document.createElement("li");
+      li.classList.add("received-type-" + (entry && entry.type ? entry.type : "ready"));
+      const body = document.createElement("div");
+      body.className = "received-body";
+      const textNode = document.createElement("div");
+      const textValue = resolveReceivedText(entry);
+      textNode.className = "received-text" + (textValue ? "" : " empty");
+      textNode.textContent = textValue || "Без текста";
+      body.appendChild(textNode);
+      const meta = document.createElement("div");
+      meta.className = "received-meta";
+      const nameNode = document.createElement("span");
+      nameNode.className = "received-name";
+      nameNode.textContent = name || "—";
+      meta.appendChild(nameNode);
+      const lenValue = getReceivedLength(entry);
+      if (lenValue && lenValue > 0) {
+        const lenNode = document.createElement("span");
+        lenNode.className = "received-length";
+        lenNode.textContent = lenValue + " байт";
+        meta.appendChild(lenNode);
+      }
+      body.appendChild(meta);
+      li.appendChild(body);
+      const actions = document.createElement("div");
+      actions.className = "received-actions";
+      const copyBtn = document.createElement("button");
+      copyBtn.type = "button";
+      copyBtn.className = "icon-btn ghost";
+      copyBtn.textContent = "⧉";
+      copyBtn.title = "Скопировать имя";
+      copyBtn.addEventListener("click", () => copyReceivedName(name));
+      actions.appendChild(copyBtn);
+      li.appendChild(actions);
+      if (isNew) {
+        li.classList.add("fresh");
+        setTimeout(() => li.classList.remove("fresh"), 1600);
+      }
+      frag.appendChild(li);
     }
     logReceivedMessage(entry, { isNew });
-    frag.appendChild(li);
   });
-  UI.els.recvList.appendChild(frag);
+  if (hasList && frag) {
+    UI.els.recvList.appendChild(frag);
+  }
   UI.state.receivedKnown = next;
   if (UI.els.recvEmpty) UI.els.recvEmpty.hidden = list.length > 0;
 }

--- a/web/style.css
+++ b/web/style.css
@@ -327,6 +327,7 @@ main {
 .chat-input { display:flex; gap:.6rem; margin-top:.8rem; }
 .chat-input button { min-width: 7.5rem; }
 .chat-input-row { display:grid; gap:.6rem; grid-template-columns: 1fr; margin-top:.8rem; }
+.chat-recv-controls { margin-top: .8rem; }
 .cmd-buttons { display:flex; gap:.4rem; flex-wrap:wrap; }
 .send-row { position: relative; display:flex; gap:.5rem; }
 #chatInput {

--- a/web/web_content.h
+++ b/web/web_content.h
@@ -38,7 +38,7 @@ const char INDEX_HTML[] PROGMEM = R"~~~(
       <h2>Chat</h2>
       <div id="chatLog" class="chat-log"></div>
       <div class="chat-input">
-        <input id="chatInput" type="text" placeholder="Сообщение" />
+        <input id="chatInput" type="text" placeholder="Сообщение" maxlength="2000" />
         <button id="sendBtn" class="btn">Отправить</button>
       </div>
       <div class="group-title"><span>Состояние ACK</span><span class="line"></span></div>
@@ -65,21 +65,16 @@ const char INDEX_HTML[] PROGMEM = R"~~~(
         <input id="txlSize" type="number" min="1" max="8192" value="1024" />
         <button id="btnTxlSend" class="btn">Отправить тест</button>
       </div>
-      <div class="group-title"><span>Принятые сообщения</span><span class="line"></span></div>
-      <div class="received-panel">
-        <div class="received-controls">
-          <button id="btnRecvRefresh" class="btn ghost">Обновить список</button>
-          <label class="chip switch">
-            <input type="checkbox" id="recvAuto" />
-            <span>Автообновление</span>
-          </label>
-          <label class="chip input-chip">
-            <span>Предел</span>
-            <input id="recvLimit" type="number" min="1" max="200" value="20" />
-          </label>
-        </div>
-        <ul id="recvList" class="received-list"></ul>
-        <div id="recvEmpty" class="muted small" hidden>Нет готовых сообщений</div>
+      <div class="chat-recv-controls received-controls">
+        <button id="btnRecvRefresh" class="btn ghost">Обновить входящие</button>
+        <label class="chip switch">
+          <input type="checkbox" id="recvAuto" />
+          <span>Автообновление</span>
+        </label>
+        <label class="chip input-chip">
+          <span>Предел</span>
+          <input id="recvLimit" type="number" min="1" max="200" value="20" />
+        </label>
       </div>
     </section>
     <!-- Вкладка каналов и пинга -->


### PR DESCRIPTION
## Summary
- убран отдельный блок "Принятые сообщения" и управляющие элементы перенесены рядом с чатом
- входящие сообщения теперь отображаются непосредственно в чат-логе, при этом сохраняется логика автозапроса
- увеличен лимит поля ввода сообщения до 2000 символов и слегка обновлены стили для новых контролов

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d043da7d6483309b678ab9502ae402