### PR TITLE
Приоритет готовых пакетов в ReceivedBuffer

### DIFF
--- a/libs/received_buffer/received_buffer.cpp
+++ b/libs/received_buffer/received_buffer.cpp
@@ -102,9 +102,9 @@ std::vector<std::string> ReceivedBuffer::list(size_t count) const {
       ++produced;
     }
   };
-  append(raw_);
-  append(split_);
   append(ready_);
+  append(split_);
+  append(raw_);
   return out;                                  // возвращаем список имён
 }
 
@@ -125,9 +125,9 @@ std::vector<ReceivedBuffer::SnapshotEntry> ReceivedBuffer::snapshot(size_t count
       ++produced;
     }
   };
-  append(raw_, Kind::Raw);
-  append(split_, Kind::Split);
   append(ready_, Kind::Ready);
+  append(split_, Kind::Split);
+  append(raw_, Kind::Raw);
   return out;
 }
 

--- a/tests/test_received_buffer.cpp
+++ b/tests/test_received_buffer.cpp
@@ -16,7 +16,12 @@ int main() {
   assert(n3 == "GO-00005");
   auto names = buf.list(10);                      // проверяем формирование списка имён
   assert(names.size() == 3);                      // ожидаем три элемента
-  assert(names[0] == n1 && names[1] == n2 && names[2] == n3);
+  assert(names[0] == n3 && names[1] == n2 && names[2] == n1);
+  auto snap = buf.snapshot(10);                   // проверяем порядок выдачи в снимке
+  assert(snap.size() == 3);
+  assert(snap[0].item.name == n3 && snap[0].kind == ReceivedBuffer::Kind::Ready);
+  assert(snap[1].item.name == n2 && snap[1].kind == ReceivedBuffer::Kind::Split);
+  assert(snap[2].item.name == n1 && snap[2].kind == ReceivedBuffer::Kind::Raw);
   ReceivedBuffer::Item out;
   assert(buf.popRaw(out) && out.id == 1 && out.part == 2 && out.data.size() == 2 && out.name == n1);
   assert(buf.popSplit(out) && out.id == 7 && out.data.size() == 3 && out.name == n2);


### PR DESCRIPTION
## Summary
- отдаём имена готовых пакетов первыми в методах list и snapshot
- обновляем модульный тест, чтобы проверить новый порядок и снимок

## Testing
- g++ -std=c++17 tests/test_received_buffer.cpp libs/received_buffer/received_buffer.cpp -I. -o test_received_buffer
- ./test_received_buffer

------
https://chatgpt.com/codex/tasks/task_e_68d2f0f4d0548330a4dda4aebae88169