### PR TITLE
Fix convolutional fragment handling and extend full-flow test

### DIFF
--- a/libs/frame/frame_header.h
+++ b/libs/frame/frame_header.h
@@ -19,8 +19,9 @@ struct FrameHeader {
   uint16_t frame_crc = 0;   // CRC всего кадра
 
   static constexpr size_t SIZE = 20; // размер заголовка в байтах
-  static constexpr uint8_t FLAG_ENCRYPTED = 0x01;   // полезная нагрузка зашифрована
+  static constexpr uint8_t FLAG_ENCRYPTED = 0x01;    // полезная нагрузка зашифрована
   static constexpr uint8_t FLAG_ACK_REQUIRED = 0x02; // требуется подтверждение доставки
+  static constexpr uint8_t FLAG_CONV_ENCODED = 0x04; // полезная нагрузка прошла свёрточное кодирование
 
   // Кодирование заголовка в буфер (big-endian) с подсчётом CRC
   bool encode(uint8_t* out, size_t out_len, const uint8_t* payload, size_t payload_len);

--- a/rx_module.h
+++ b/rx_module.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <array>
 #include <vector>
+#include <unordered_map>
 #include "libs/packetizer/packet_gatherer.h" // сборщик пакетов
 #include "libs/received_buffer/received_buffer.h" // буфер принятых сообщений
 #include "default_settings.h"
@@ -37,4 +38,9 @@ private:
   std::vector<uint8_t> plain_buf_;   // буфер расшифрованных данных
   uint32_t raw_counter_ = 0;         // счётчик сырых пакетов без заголовка
   bool encryption_forced_ = DefaultSettings::USE_ENCRYPTION; // ожидание шифрования по умолчанию
+  struct PendingConvBlock {
+    size_t expected_len = 0;           // ожидаемая длина свёрнутого блока
+    std::vector<uint8_t> data;         // накопленные байты для последующего декодирования
+  };
+  std::unordered_map<uint64_t, PendingConvBlock> pending_conv_; // буферизация неполных свёрточных блоков
 };


### PR DESCRIPTION
## Summary
- add a dedicated flag in FrameHeader to mark convolutionally encoded payloads and keep track of block metadata
- update TxModule to limit blocks before convolution, add encoder tail bytes, avoid cutting coded fragments, and propagate metadata through ack_mask
- extend RxModule to buffer partial convolution blocks, remove the artificial tail after decoding, and use the stored metadata for nonce reconstruction
- enhance the full flow test to accumulate fragments and cover payloads larger than a single block

## Testing
- g++ -I. -I.. tests/test_full_flow.cpp tx_module.cpp rx_module.cpp message_buffer.cpp libs_includes.cpp -std=c++17 && ./a.out
- g++ -I. -I.. tests/test_processing_without_send.cpp tx_module.cpp rx_module.cpp message_buffer.cpp libs_includes.cpp -std=c++17 && ./a.out

------
https://chatgpt.com/codex/tasks/task_e_68d2f71f79c0833090e8e1943fb27bd0