### PR TITLE
Ускорена отправка ACK при ожидании

### DIFF
--- a/tx_module.h
+++ b/tx_module.h
@@ -61,6 +61,7 @@ private:
   void scheduleFromArchive();
   void onSendSuccess();
   void waitForPauseWindow();
+  bool processImmediateAck();
 
   IRadio& radio_;
   std::array<MessageBuffer,4> buffers_;             // очереди сообщений по классам QoS
@@ -76,6 +77,8 @@ private:
   std::optional<PendingMessage> inflight_;          // текущий пакет в работе
   std::optional<PendingMessage> delayed_;           // пакет из архива, готовый к отправке
   std::deque<PendingMessage> archive_;              // архив сообщений без ACK
+  std::deque<PendingMessage> ack_queue_;            // очередь мгновенных ACK-сообщений
+  uint32_t next_ack_id_ = 0x80000000u;              // идентификаторы ACK вне общей очереди
   bool encryption_enabled_ = DefaultSettings::USE_ENCRYPTION; // текущий режим шифрования
 };
 


### PR DESCRIPTION
## Summary
- вынес подтверждения ACK в отдельную очередь, чтобы отправлять их даже при ожидании ответов на другие сообщения
- добавил защиту от повторного использования идентификаторов и пометил новую логику в журнале отладки

## Testing
- g++ -I. -I.. tests/test_processing_without_send.cpp tx_module.cpp rx_module.cpp message_buffer.cpp libs_includes.cpp -std=c++17 -o test && ./test

------
https://chatgpt.com/codex/tasks/task_e_68d59bce4a948330902fa635e06da0e7