### PR TITLE
Добавлен повторный монтаж SPIFFS и диагностика ошибок

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@
 | `frame` | Структуры заголовков кадров (`FrameHeader`). |
 | `key_loader`, `crypto/aes_ccm`, `key_transfer` | Работа с ключами, AES-CCM и обмен корневым ключом. |
 | `simple_logger`, `serial_program_collector`, `text_converter` | Логирование, сборка команд, преобразование текста. |
-| `fs_utils` | Хелпер `ensureSpiffsMounted()` монтирует SPIFFS и при необходимости форматирует раздел один раз. |
+| `fs_utils` | Хелпер `ensureSpiffsMounted()` возвращает `SpiffsMountResult` с причиной и повторно пытается форматировать/монтировать SPIFFS. |
 
 Файл `libs_includes.cpp` подключает реализации библиотек для Arduino-проекта и избавляет от
 неявных зависимостей.
@@ -464,8 +464,9 @@ ENCT: успех
   создаётся запись по умолчанию).
 - `bool saveKey(const std::array<uint8_t,16>& key, KeyOrigin origin, const std::array<uint8_t,32>* peer,
   uint32_t salt)` — сохранить ключ с указанием происхождения и публичного ключа собеседника.
-- `bool generateLocalKey(KeyRecord* out = nullptr)` — создать новую пару Curve25519, обновить
-  симметричный ключ и резервную копию.
+- `bool generateLocalKey(KeyRecord* out = nullptr, fs_utils::SpiffsMountResult* status = nullptr)` —
+  создать новую пару Curve25519, обновить симметричный ключ и резервную копию, дополнительно
+  возвращая состояние монтирования SPIFFS (для сообщений пользователю).
 - `bool restorePreviousKey(KeyRecord* out = nullptr)` — восстановить `key.stkey` из резервной копии.
 - `bool applyRemotePublic(const std::array<uint8_t,32>& remote)` — вычислить общий секрет и сохранить
   внешний симметричный ключ.

--- a/libs/key_loader/key_loader.h
+++ b/libs/key_loader/key_loader.h
@@ -3,6 +3,10 @@
 #include <cstdint>
 #include <optional>
 
+namespace fs_utils {
+struct SpiffsMountResult;
+}
+
 namespace KeyLoader {
 
 // Происхождение активного ключа
@@ -48,7 +52,8 @@ bool saveKey(const std::array<uint8_t,16>& key,
 
 // Запись нового локального ключа (генерация пары Curve25519 и симметричного ключа из неё).
 // При сохранении предыдущая версия переименовывается в key.stkey.old (если была).
-bool generateLocalKey(KeyRecord* out = nullptr);
+bool generateLocalKey(KeyRecord* out = nullptr,
+                      fs_utils::SpiffsMountResult* mount_status = nullptr);
 
 // Восстановление предыдущего ключа (если существует key.stkey.old).
 bool restorePreviousKey(KeyRecord* out = nullptr);


### PR DESCRIPTION
## Summary
- добавить структуру SpiffsMountResult и расширенные статусы монтирования SPIFFS
- обновить KeyLoader и HTTP-обработчики для передачи причины сбоя и JSON-ответов
- задокументировать новые параметры и поведение в README

## Testing
- g++ -std=c++17 tests/test_keyloader.cpp libs/key_loader/key_loader.cpp libs/crypto/sha256.cpp libs/crypto/x25519.cpp libs/crypto/curve25519_donna.cpp -I. -o /tmp/test_keyloader
- /tmp/test_keyloader

------
https://chatgpt.com/codex/tasks/task_e_68d5a601a7188330a53ed0a7d1983522