### PR TITLE
Fix SPIFFS header namespace pollution

### DIFF
--- a/libs/fs_utils/spiffs_guard.h
+++ b/libs/fs_utils/spiffs_guard.h
@@ -5,6 +5,23 @@
 
 #include <cstdint>
 
+#ifdef ARDUINO
+#include <Arduino.h>
+#include <FS.h>
+#include <SPIFFS.h>
+#if defined(ESP32) && __has_include("esp_ipc.h")
+#include <esp_err.h>
+#include <esp_ipc.h>
+#define FS_UTILS_HAS_ESP_IPC 1
+#else
+#define FS_UTILS_HAS_ESP_IPC 0
+#endif
+#endif
+
+#ifndef FS_UTILS_HAS_ESP_IPC
+#define FS_UTILS_HAS_ESP_IPC 0
+#endif
+
 namespace fs_utils {
 
 // Детальное состояние операции монтирования SPIFFS.
@@ -40,17 +57,6 @@ inline const char* describeStatus(SpiffsMountStatus status) {
 }
 
 #ifdef ARDUINO
-#include <Arduino.h>
-#include <FS.h>
-#include <SPIFFS.h>
-#if defined(ESP32) && __has_include("esp_ipc.h")
-#include <esp_err.h>
-#include <esp_ipc.h>
-#define FS_UTILS_HAS_ESP_IPC 1
-#else
-#define FS_UTILS_HAS_ESP_IPC 0
-#endif
-
 // Обёртка над SPIFFS.begin() с повторными попытками форматирования и монтирования.
 inline SpiffsMountResult ensureSpiffsMounted(bool allowFormat = true) {
   static bool mounted = false;


### PR DESCRIPTION
## Summary
- вынес подключение заголовков Arduino из пространства имён `fs_utils`, чтобы не ломать глобальные символы `SPIFFS` и `File`
- добавил запасное определение `FS_UTILS_HAS_ESP_IPC`, чтобы хостовые сборки тоже компилировались

## Testing
- not run (не предусмотрено в задаче)


------
https://chatgpt.com/codex/tasks/task_e_68d5af811b2483308a485165240fbc20