### PR TITLE
Handle zero ACK retry limit in TxModule

### DIFF
--- a/tx_module.cpp
+++ b/tx_module.cpp
@@ -512,6 +512,18 @@ void TxModule::setAckRetryLimit(uint8_t retries) {
     delayed_->attempts_left = ack_retry_limit_;
     delayed_->expect_ack = ack_enabled_ && ack_retry_limit_ != 0 && !isAckPayload(delayed_->data);
   }
+  if (ack_retry_limit_ == 0 && waiting_ack_) {
+    // При обнулении лимита считаем пакет доставленным и не ждём ACK
+    waiting_ack_ = false;
+    if (inflight_) {
+      if (!inflight_->status_prefix.empty()) {
+        SimpleLogger::logStatus(inflight_->status_prefix + " GO");
+      }
+      inflight_->attempts_left = ack_retry_limit_;
+      inflight_.reset();
+    }
+    onSendSuccess();
+  }
 }
 
 void TxModule::onAckReceived() {


### PR DESCRIPTION
## Summary
- finalize in-flight packets when the ACK retry limit is set to zero so they are not archived
- extend TxModule tests with scenarios that cover zero retry limit behavior without waiting for timeouts

## Testing
- `g++ -std=c++17 -I. -Ilibs tests/test_tx_module.cpp tx_module.cpp message_buffer.cpp -o test_tx_module` *(fails: missing linked library implementations such as PacketSplitter, KeyLoader, and codec helpers)*

------
https://chatgpt.com/codex/tasks/task_e_68d6513a71f48330b8a22c9aa6b18258