### PR TITLE
Log warning for single valid header in RX path

### DIFF
--- a/rx_module.cpp
+++ b/rx_module.cpp
@@ -162,6 +162,10 @@ void RxModule::onReceive(const uint8_t* data, size_t len) {
     return;
   }
 
+  if (primary_ok != secondary_ok) {
+    LOG_WARN("RxModule: обнаружено расхождение валидности копий заголовка"); // фиксируем частичный сбой
+    // В текущей реализации отдельный счётчик доверия не ведётся, поэтому дополнительных действий не требуется.
+  }
   FrameHeader hdr = primary_ok ? primary_hdr : secondary_hdr;
   if (primary_ok && secondary_ok) {
     bool headers_match = (primary_hdr.msg_id == secondary_hdr.msg_id) &&

--- a/tests/test_rx_profiling.cpp
+++ b/tests/test_rx_profiling.cpp
@@ -1,6 +1,9 @@
 #include <cassert>
 #include <vector>
 #include <array>
+#include <sstream>
+#include <iostream>
+#include <algorithm>
 #include "tx_module.h"
 #include "rx_module.h"
 #include "libs/frame/frame_header.h"
@@ -23,6 +26,7 @@ int main() {
 
   RxModule rx;
   rx.enableProfiling(true);                              // включаем диагностику пути
+  rx.setEncryptionEnabled(false);                        // отключаем принудительное дешифрование для чистых кадров
 
   std::vector<uint8_t> received;
   rx.setCallback([&](const uint8_t* data, size_t len) {
@@ -57,10 +61,13 @@ int main() {
   primary_hdr.msg_id = 7;
   primary_hdr.frag_idx = 0;
   primary_hdr.frag_cnt = 1;
-  primary_hdr.payload_len = 4;
   std::array<uint8_t, FrameHeader::SIZE> hdr_buf1{};
   std::array<uint8_t, FrameHeader::SIZE> hdr_buf2{};
-  std::array<uint8_t, 4> fake_payload{0x10, 0x20, 0x30, 0x40};
+  std::array<uint8_t, 4> expected_plain{0x10, 0x20, 0x30, 0x40};
+  std::array<uint8_t, 12> fake_payload{0x10, 0x20, 0x30, 0x40,
+                                       0xA0, 0xA1, 0xA2, 0xA3,
+                                       0xA4, 0xA5, 0xA6, 0xA7};
+  primary_hdr.payload_len = static_cast<uint16_t>(fake_payload.size());
   bool encoded_primary = primary_hdr.encode(hdr_buf1.data(), hdr_buf1.size(),
                                             fake_payload.data(), fake_payload.size());
   assert(encoded_primary);
@@ -69,6 +76,23 @@ int main() {
   bool encoded_secondary = secondary_hdr.encode(hdr_buf2.data(), hdr_buf2.size(),
                                                 fake_payload.data(), fake_payload.size());
   assert(encoded_secondary);
+  std::vector<uint8_t> single_header_frame;
+  single_header_frame.insert(single_header_frame.end(), hdr_buf1.begin(), hdr_buf1.end());
+  auto corrupted_hdr = hdr_buf1;
+  corrupted_hdr[16] ^= 0xFF;                                // повреждаем CRC заголовка
+  single_header_frame.insert(single_header_frame.end(), corrupted_hdr.begin(), corrupted_hdr.end());
+  single_header_frame.insert(single_header_frame.end(), fake_payload.begin(), fake_payload.end());
+  scrambler::scramble(single_header_frame.data(), single_header_frame.size()); // имитируем передачу
+  received.clear();
+  std::ostringstream log_capture;                          // перехватываем журнал
+  auto* prev_buf = std::cout.rdbuf(log_capture.rdbuf());   // перенаправляем поток
+  rx.onReceive(single_header_frame.data(), single_header_frame.size());
+  std::cout.rdbuf(prev_buf);                               // возвращаем стандартный вывод
+  auto log_text = log_capture.str();
+  assert(received.size() == expected_plain.size());        // проверяем длину полезной нагрузки
+  assert(std::equal(received.begin(), received.end(), expected_plain.begin())); // убеждаемся, что байты совпадают
+  assert(log_text.find("RxModule: обнаружено расхождение валидности копий заголовка") != std::string::npos);
+
   std::vector<uint8_t> mismatched_frame;
   mismatched_frame.insert(mismatched_frame.end(), hdr_buf1.begin(), hdr_buf1.end());
   mismatched_frame.insert(mismatched_frame.end(), hdr_buf2.begin(), hdr_buf2.end());


### PR DESCRIPTION
## Summary
- log a warning when only one of the duplicated frame headers decodes successfully in the RX module
- extend the RX profiling test to cover a frame with a single valid header and verify that the warning is emitted while the payload is delivered

## Testing
- g++ -std=c++17 tests/test_rx_profiling.cpp rx_module.cpp tx_module.cpp message_buffer.cpp libs_includes.cpp -I. -o test_rx_profiling && ./test_rx_profiling

------
https://chatgpt.com/codex/tasks/task_e_68d765f0b2808330a505127af36bcee2