### PR TITLE
Оптимизация буферов передачи

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,8 @@ ENCT: успех
 ## Справочник API
 
 ### MessageBuffer
-- `MessageBuffer(size_t capacity)` — создать буфер с ограничением на число сообщений.
+- `MessageBuffer(size_t capacity, size_t slot_size = 256)` — создать буфер с ограничением на число
+  сообщений и фиксированным размером слота под каждый фрагмент без повторного выделения памяти.
 - `uint32_t enqueue(const uint8_t* data, size_t len)` — добавить сообщение, при переполнении вернуть
   `0`.
 - `size_t freeSlots() const` — количество свободных слотов.
@@ -385,6 +386,7 @@ ENCT: успех
 - `bool pop(uint32_t& id, std::vector<uint8_t>& out)` — извлечь сообщение и его идентификатор.
 - `const std::vector<uint8_t>* peek(uint32_t& id) const` — указатель на данные первого сообщения без
   извлечения.
+- `size_t slotSize() const` — узнать, какой объём данных допустим в одном слоте очереди.
 
 ### ReceivedBuffer
 - `std::string pushRaw(uint32_t id, uint32_t part, const uint8_t* data, size_t len)` — сохранить

--- a/libs/simple_logger/simple_logger.cpp
+++ b/libs/simple_logger/simple_logger.cpp
@@ -1,30 +1,67 @@
 #include "simple_logger.h"
+#include <array>
+#include <string_view>
 
-// Статический буфер журнала
-static std::vector<std::string> g_log;
+namespace {
+// Максимальный размер кольцевого буфера
+constexpr size_t MAX_LOG_RECORDS = 64;
+
+// Запись журнала с сохранённым префиксом
+struct LogEntry {
+  std::string prefix;   // префикс до первого пробела
+  std::string line;     // полная строка журнала
+};
+
+std::array<LogEntry, MAX_LOG_RECORDS> g_log{}; // кольцевой буфер записей
+size_t g_head = 0;                             // индекс старейшей записи
+size_t g_size = 0;                             // текущее количество строк
+
+// Поиск записи по префиксу для замены
+LogEntry* findByPrefix(std::string_view prefix) {
+  for (size_t i = 0; i < g_size; ++i) {
+    size_t idx = (g_head + i) % g_log.size();
+    if (g_log[idx].prefix == prefix) {
+      return &g_log[idx];
+    }
+  }
+  return nullptr;
+}
+} // namespace
 
 namespace SimpleLogger {
 void logStatus(const std::string& line) {
   // Выделяем префикс до первого пробела
   auto pos = line.find(' ');
-  std::string prefix = (pos == std::string::npos) ? line : line.substr(0, pos);
-  // Ищем существующую запись с таким же префиксом и заменяем её
-  for (auto &entry : g_log) {
-    auto epos = entry.find(' ');
-    std::string eprefix = (epos == std::string::npos) ? entry : entry.substr(0, epos);
-    if (eprefix == prefix) {
-      entry = line;
-      return;
-    }
+  std::string_view prefix_view = (pos == std::string::npos)
+                                   ? std::string_view(line)
+                                   : std::string_view(line.data(), pos);
+  if (LogEntry* existing = findByPrefix(prefix_view)) {
+    existing->line = line;                       // обновляем строку без перевыделения
+    return;
   }
-  // Если не найдено, добавляем новую строку
-  g_log.push_back(line);
+
+  size_t index;
+  if (g_size < g_log.size()) {
+    index = (g_head + g_size) % g_log.size();    // используем свободный слот
+    ++g_size;
+  } else {
+    index = g_head;                              // перезаписываем самую старую запись
+    g_head = (g_head + 1) % g_log.size();
+  }
+  LogEntry& entry = g_log[index];
+  entry.prefix.assign(prefix_view.data(), prefix_view.size());
+  entry.line = line;
 }
 
 std::vector<std::string> getLast(size_t count) {
+  if (count > g_size) count = g_size;
   std::vector<std::string> out;
-  if (count > g_log.size()) count = g_log.size();
-  out.assign(g_log.end() - count, g_log.end());
+  out.reserve(count);
+  size_t start = g_size - count;
+  for (size_t i = start; i < g_size; ++i) {
+    size_t idx = (g_head + i) % g_log.size();
+    out.push_back(g_log[idx].line);
+  }
   return out;
 }
 } // namespace SimpleLogger

--- a/libs/simple_logger/simple_logger.h
+++ b/libs/simple_logger/simple_logger.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <vector>
 #include <string>
+#include <cstddef>
 
 // Простейший журнал статусов сообщений
 namespace SimpleLogger {


### PR DESCRIPTION
## Summary
- реализован кольцевой MessageBuffer с фиксированными слотами и новым accessor slotSize
- переработаны PacketSplitter и TxModule для повторного использования предварительно выделенных буферов
- ограничен журнал simple_logger кольцевым буфером и обновлена документация по MessageBuffer

## Testing
- /tmp/test_message_buffer
- /tmp/test_packet_splitter

------
https://chatgpt.com/codex/tasks/task_e_68d78966e99c8330a2927af41762a6b3