### PR TITLE
Set JSON content type for JSON HTTP responses

### DIFF
--- a/serial_radio_control.ino
+++ b/serial_radio_control.ino
@@ -1685,6 +1685,7 @@ void handleCmdHttp() {
     resp = cmdTx(payload);
   } else if (cmd == "ENCT") {
     resp = cmdEnct();
+    contentType = "application/json"; // Ответ в формате JSON
   } else if (cmd == "TESTRXM") {
     bool hasOverride = false;
     String overrideText;
@@ -1703,11 +1704,14 @@ void handleCmdHttp() {
     }
     if (hasOverride) {
       resp = cmdTestRxm(&overrideText);
+      contentType = "application/json"; // Ответ в формате JSON
     } else {
       resp = cmdTestRxm();
+      contentType = "application/json"; // Ответ в формате JSON
     }
   } else if (cmd == "KEYSTATE") {
     resp = cmdKeyState();
+    contentType = "application/json"; // Ответ в формате JSON
   } else if (cmd == "KEYSTORE") {
     String arg;
     if (server.hasArg("mode")) {
@@ -1718,22 +1722,30 @@ void handleCmdHttp() {
       arg = cmdArg;
     }
     resp = cmdKeyStorage(arg);
+    contentType = "application/json"; // Ответ в формате JSON
   } else if (cmd == "KEYGEN") {
     resp = cmdKeyGenSecure();
+    contentType = "application/json"; // Ответ в формате JSON
   } else if (cmd == "KEYRESTORE") {
     resp = cmdKeyRestoreSecure();
+    contentType = "application/json"; // Ответ в формате JSON
   } else if (cmd == "KEYSEND") {
     resp = cmdKeyTransferSendLora();
+    contentType = "application/json"; // Ответ в формате JSON
   } else if (cmd == "KEYRECV") {
     String hex = server.hasArg("pub") ? server.arg("pub") : String();
     resp = cmdKeyReceiveSecure(hex);
+    contentType = "application/json"; // Ответ в формате JSON
   } else if (cmd == "KEYTRANSFER") {
     if (cmdArg == "SEND") {
       resp = cmdKeyTransferSendLora();
+      contentType = "application/json"; // Ответ в формате JSON
     } else if (cmdArg == "RECEIVE") {
       resp = cmdKeyTransferReceiveLora();
+      contentType = "application/json"; // Ответ в формате JSON
     } else {
       resp = String("{\"error\":\"mode\"}");
+      contentType = "application/json"; // Ответ в формате JSON
     }
   } else {
     resp = "UNKNOWN";


### PR DESCRIPTION
## Summary
- set HTTP content type to application/json for command handlers returning JSON payloads
- keep text responses as text/plain while clarifying JSON responses with inline comments

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7bd2a63ac833089d128d2953d9faa