### PR TITLE
Исключили раннее выделение памяти в MessageBuffer

### DIFF
--- a/message_buffer.cpp
+++ b/message_buffer.cpp
@@ -14,9 +14,8 @@ MessageBuffer::MessageBuffer(size_t capacity, size_t slot_size) {
   capacity_ = capacity;
   slot_size_ = slot_size;
   slots_.resize(capacity_);
-  for (auto& slot : slots_) {
-    slot.data.reserve(slot_size_);              // заранее выделяем память под фрагменты
-  }
+  // Не пытаемся заранее выделить память под все слоты, чтобы не спровоцировать
+  // std::bad_alloc на устройствах с ограниченным ОЗУ (ESP32 и подобные).
 }
 
 // Добавление сообщения в буфер


### PR DESCRIPTION
## Summary
- убрал предварительное резервирование памяти для всех слотов MessageBuffer, чтобы не ловить std::bad_alloc на устройствах с малым объёмом ОЗУ

## Testing
- g++ -std=c++20 -I. tests/test_message_buffer.cpp message_buffer.cpp -o /tmp/test_message_buffer && /tmp/test_message_buffer

------
https://chatgpt.com/codex/tasks/task_e_68d83b6b13348330aa98f50b17aab3a3