### PR TITLE
Sort public keys before deriving sessions

### DIFF
--- a/libs/key_loader/key_loader.cpp
+++ b/libs/key_loader/key_loader.cpp
@@ -96,8 +96,12 @@ std::array<uint8_t,16> deriveSessionFromShared(const std::array<uint8_t,32>& sha
                                                const std::array<uint8_t,32>& remote_pub) {
   std::array<uint8_t,96> buf{};
   std::copy(shared.begin(), shared.end(), buf.begin());
-  std::copy(local_pub.begin(), local_pub.end(), buf.begin() + shared.size());
-  std::copy(remote_pub.begin(), remote_pub.end(), buf.begin() + shared.size() + local_pub.size());
+  std::array<std::array<uint8_t,32>, 2> ordered_pubs = {local_pub, remote_pub};
+  std::sort(ordered_pubs.begin(), ordered_pubs.end());
+  // Сортируем публичные ключи, чтобы обе стороны формировали одинаковый буфер.
+  std::copy(ordered_pubs[0].begin(), ordered_pubs[0].end(), buf.begin() + shared.size());
+  std::copy(ordered_pubs[1].begin(), ordered_pubs[1].end(),
+            buf.begin() + shared.size() + ordered_pubs[0].size());
   auto digest = crypto::sha256::hash(buf.data(), buf.size());
   return truncateDigest(digest);
 }

--- a/tests/test_keyloader.cpp
+++ b/tests/test_keyloader.cpp
@@ -53,8 +53,12 @@ int main() {
   assert(shared_remote == shared_local);
   std::array<uint8_t,96> buf{};
   std::copy(shared_local.begin(), shared_local.end(), buf.begin());
-  std::copy(rec2.root_public.begin(), rec2.root_public.end(), buf.begin() + shared_local.size());
-  std::copy(remote_pub.begin(), remote_pub.end(), buf.begin() + shared_local.size() + rec2.root_public.size());
+  std::array<std::array<uint8_t,32>, 2> ordered_pubs = {rec2.root_public, remote_pub};
+  std::sort(ordered_pubs.begin(), ordered_pubs.end());
+  // Буфер формируется идентично прошивке: сортируем ключи и конкатенируем.
+  std::copy(ordered_pubs[0].begin(), ordered_pubs[0].end(), buf.begin() + shared_local.size());
+  std::copy(ordered_pubs[1].begin(), ordered_pubs[1].end(),
+            buf.begin() + shared_local.size() + ordered_pubs[0].size());
   auto digest = crypto::sha256::hash(buf.data(), buf.size());
   std::array<uint8_t,16> expected{};
   std::copy_n(digest.begin(), expected.size(), expected.begin());


### PR DESCRIPTION
## Summary
- sort the local and remote public keys before hashing the shared secret to keep session derivation symmetric
- adjust the key loader test to build the expected digest using the same deterministic ordering

## Testing
- g++ -std=c++17 -I. tests/test_keyloader.cpp libs/key_loader/key_loader.cpp libs/crypto/sha256.cpp libs/crypto/x25519.cpp libs/crypto/curve25519_donna.cpp -o test_keyloader
- ./test_keyloader

------
https://chatgpt.com/codex/tasks/task_e_68d8db805d208330a1d96323957fe038