### PR TITLE
Use received EventSource event for chat updates

### DIFF
--- a/web/script.js
+++ b/web/script.js
@@ -3656,7 +3656,7 @@ function openReceivedPushChannel() {
       startReceivedMonitor({ intervalMs: 30000, immediate: false });
       updateReceivedMonitorDiagnostics();
     });
-    source.addEventListener("message", (event) => {
+    source.addEventListener("received", (event) => {
       push.connected = true;
       push.lastEventAt = Date.now();
       handleReceivedPushMessage(event);


### PR DESCRIPTION
## Summary
- switch the SSE subscription in the chat push channel to listen for the "received" event instead of the default "message" event

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8dc2d01188330ae01492accec1c10