### PR TITLE
Preserve remote key when regenerating local ECDH sessions

### DIFF
--- a/serial_radio_control.ino
+++ b/serial_radio_control.ino
@@ -1020,6 +1020,11 @@ String cmdKeyStorage(const String& mode) {
 String cmdKeyGenSecure() {
   DEBUG_LOG("Key: генерация нового ключа");
   if (KeyLoader::generateLocalKey()) {
+    const bool synced_with_peer = KeyLoader::regenerateFromPeer();
+    // Если есть сохранённый ключ удалённой стороны, пересчитываем сессию сразу.
+    if (synced_with_peer) {
+      DEBUG_LOG("Key: сессия пересчитана по сохранённому ключу удалённой стороны");
+    }
     reloadCryptoModules();
     return makeKeyStateJson();
   }


### PR DESCRIPTION
## Summary
- сохранять текущий peer_public при локальной генерации ключа, чтобы можно было пересчитать сессию
- повторно вызывать regenerateFromPeer из команды cmdKeyGenSecure и логировать синхронизацию
- расширить тест keyloader сценарием A→B→A для проверки совпадения симметричных ключей

## Testing
- g++ -std=c++17 tests/test_keyloader.cpp libs/key_loader/key_loader.cpp libs/crypto/x25519.cpp libs/crypto/sha256.cpp libs/crypto/curve25519_donna.cpp -I. -o test_keyloader
- ./test_keyloader


------
https://chatgpt.com/codex/tasks/task_e_68d8e3bb045c833095eebd81b187a5dd