### PR TITLE
Обработка первичного KEYTRANSFER без известного партнёра

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,9 @@ ENCT: успех
 - `bool restorePreviousKey(KeyRecord* out = nullptr)` — восстановить `key.stkey` из резервной копии.
 - `bool applyRemotePublic(const std::array<uint8_t,32>& remote)` — вычислить общий секрет и сохранить
   внешний симметричный ключ.
+- `bool hasPeerPublic()` — проверить, сохранён ли публичный ключ удалённого собеседника.
+- `bool previewPeerKeyId(std::array<uint8_t,4>& key_id)` — пересчитать идентификатор ECDH-ключа для
+  текущего партнёра без изменения снимка.
 - `KeyState getState()` — текущее состояние ключа (тип, идентификатор, публичные ключи, резервная
   копия).
 - `std::array<uint8_t,12> makeNonce(uint32_t msg_id, uint16_t frag_idx)` — сформировать nonce для

--- a/libs/key_loader/key_loader.h
+++ b/libs/key_loader/key_loader.h
@@ -84,6 +84,12 @@ std::array<uint8_t,12> makeNonce(uint32_t msg_id, uint16_t frag_idx);
 // 4-байтовый идентификатор ключа (первые байты SHA-256 от симметричного ключа).
 std::array<uint8_t,4> keyId(const std::array<uint8_t,16>& key);
 
+// Есть ли сохранённый публичный ключ удалённой стороны.
+bool hasPeerPublic();
+
+// Предпросчёт идентификатора ключа для текущего удалённого партнёра без изменения состояния.
+bool previewPeerKeyId(std::array<uint8_t,4>& key_id_out);
+
 // Активный бэкенд хранения (NVS/файловая система).
 StorageBackend getBackend();
 


### PR DESCRIPTION
## Summary
- скорректировал формирование кадров KEYTRANSFER: используем нулевой `key_id` при отсутствии `peer_public` и пересчитываем идентификатор через KeyLoader при известном партнёре
- добавил пропуск проверки идентификаторов на приёме для первичного обмена и расширил KeyLoader вспомогательными методами
- обновил README и тест KeyLoader для нового сценария

## Testing
- g++ -I. tests/test_keyloader.cpp libs_includes.cpp message_buffer.cpp -std=c++17 && ./a.out


------
https://chatgpt.com/codex/tasks/task_e_68d8f0d71948833093ea832d45cd1ad0