### PR TITLE
Исправление многократного определения криптографических констант

### DIFF
--- a/libs/crypto/chacha20_poly1305.h
+++ b/libs/crypto/chacha20_poly1305.h
@@ -8,9 +8,9 @@ namespace crypto {
 namespace chacha20poly1305 {
 
 // Размеры ключа, нонса и тега для варианта IETF (12-байтовый nonce)
-constexpr size_t KEY_SIZE = 32;                 // длина ключа алгоритма
-constexpr size_t NONCE_SIZE = 12;               // длина нонса
-constexpr size_t TAG_SIZE = 16;                 // длина тега Poly1305
+inline constexpr size_t KEY_SIZE = 32;                 // длина ключа алгоритма
+inline constexpr size_t NONCE_SIZE = 12;               // длина нонса
+inline constexpr size_t TAG_SIZE = 16;                 // длина тега Poly1305
 
 // Шифрование с отделённым тегом аутентичности
 // key/nonce могут иметь размеры 16 и 12 байт соответственно: ключ автоматически

--- a/libs/crypto/ed25519.h
+++ b/libs/crypto/ed25519.h
@@ -6,8 +6,8 @@
 namespace crypto {
 namespace ed25519 {
 
-constexpr size_t PUBLIC_KEY_SIZE = 32;   // размер публичного ключа Ed25519
-constexpr size_t SIGNATURE_SIZE = 64;    // размер подписи Ed25519
+inline constexpr size_t PUBLIC_KEY_SIZE = 32;   // размер публичного ключа Ed25519
+inline constexpr size_t SIGNATURE_SIZE = 64;    // размер подписи Ed25519
 
 // Проверка подписи Ed25519 над произвольным сообщением
 bool verify(const uint8_t* message, size_t message_len,


### PR DESCRIPTION
## Summary
- добавить спецификатор inline для constexpr-констант в заголовках Ed25519 и ChaCha20-Poly1305, чтобы предотвратить множественные определения при линковке

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d919bdec1c8330b57d89c0939a0a52