### PR TITLE
Add include guards to crypto headers

### DIFF
--- a/libs/crypto/chacha20_poly1305.h
+++ b/libs/crypto/chacha20_poly1305.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#ifndef SATPRJCT_LIBS_CRYPTO_CHACHA20_POLY1305_H_
+#define SATPRJCT_LIBS_CRYPTO_CHACHA20_POLY1305_H_
+
 #include <cstddef>
 #include <cstdint>
 #include <vector>
@@ -34,4 +37,6 @@ bool decrypt(const uint8_t* key, size_t key_len,
 
 } // namespace chacha20poly1305
 } // namespace crypto
+
+#endif  // SATPRJCT_LIBS_CRYPTO_CHACHA20_POLY1305_H_
 

--- a/libs/crypto/ed25519.h
+++ b/libs/crypto/ed25519.h
@@ -1,4 +1,7 @@
 #pragma once
+
+#ifndef SATPRJCT_LIBS_CRYPTO_ED25519_H_
+#define SATPRJCT_LIBS_CRYPTO_ED25519_H_
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -16,4 +19,6 @@ bool verify(const uint8_t* message, size_t message_len,
 
 }  // namespace ed25519
 }  // namespace crypto
+
+#endif  // SATPRJCT_LIBS_CRYPTO_ED25519_H_
 


### PR DESCRIPTION
## Summary
- add explicit include guards to the Ed25519 helper header
- add explicit include guards to the ChaCha20-Poly1305 helper header to avoid duplicate constant definitions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d91e5d1d4883309f14714bc2d054c0