### PR TITLE
Increase LoRa preamble length to 16 symbols

### DIFF
--- a/default_settings.h
+++ b/default_settings.h
@@ -42,6 +42,7 @@ namespace DefaultSettings {
   // Уровни журналирования для фильтрации сообщений
   enum class LogLevel : uint8_t { ERROR = 0, WARN = 1, INFO = 2, DEBUG = 3 };
   constexpr LogLevel LOG_LEVEL = LogLevel::DEBUG;   // Текущий уровень вывода
+  constexpr uint16_t PREAMBLE_LENGTH = 16;          // Длина преамбулы LoRa (символы)
   // Ключ шифрования по умолчанию (16 байт)
   constexpr std::array<uint8_t, 16> DEFAULT_KEY{
       0x00, 0x01, 0x02, 0x03,

--- a/radio_sx1262.cpp
+++ b/radio_sx1262.cpp
@@ -309,7 +309,7 @@ bool RadioSX1262::resetToDefaults() {
   int state = radio_.begin(
       fRX_bank_[static_cast<int>(bank_)][channel_],
       BW_[bw_preset_], SF_[sf_preset_], CR_[cr_preset_],
-      0x18, Pwr_[pw_preset_], 10, tcxo_, false);
+      0x18, Pwr_[pw_preset_], DefaultSettings::PREAMBLE_LENGTH, tcxo_, false);
   if (state != RADIOLIB_ERR_NONE) {
     return false;                                         // ошибка инициализации
   }


### PR DESCRIPTION
## Summary
- add a default setting for LoRa preamble length set to 16 symbols
- apply the new preamble length when initializing the SX1262 radio

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9f7162770833087d265decfeaee21