### PR TITLE
Align AEAD metadata derivation with compact frame header

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,8 +677,7 @@ g++ -I. tests/test_key_transfer.cpp \
   текущего партнёра без изменения снимка.
 - `KeyState getState()` — текущее состояние ключа (тип, идентификатор, публичные ключи, резервная
   копия).
-- `std::array<uint8_t,12> makeNonce(uint32_t packed_meta, uint16_t msg_id)` — сформировать nonce для
-  AEAD (ChaCha20-Poly1305 и совместимого режима AES-CCM).
+- `std::array<uint8_t,12> makeNonce(uint8_t version, uint16_t frag_cnt, uint32_t packed_meta, uint16_t msg_id)` — сформировать нонс для AEAD (ChaCha20-Poly1305 и совместимого режима AES-CCM).
 - `bool startEphemeralSession(std::array<uint8_t,32>& public_out, bool force_new = true)` — подготовить
   эпемерную пару X25519 и вернуть публичный ключ для включения в кадр обмена.
 - `bool hasEphemeralSession()` — проверить, активна ли временная пара для текущего сеанса.

--- a/libs/key_loader/key_loader.h
+++ b/libs/key_loader/key_loader.h
@@ -80,8 +80,11 @@ KeyState getState();
 // Публичный корневой ключ устройства.
 std::array<uint8_t,32> getPublicKey();
 
-// Генерация нонса для AES-CCM на основе идентификатора сообщения и индекса фрагмента.
-std::array<uint8_t,12> makeNonce(uint32_t packed_meta, uint16_t msg_id);
+// Генерация нонса для AEAD по компактному заголовку и 16-битному идентификатору сообщения.
+std::array<uint8_t,12> makeNonce(uint8_t version,
+                                 uint16_t frag_cnt,
+                                 uint32_t packed_meta,
+                                 uint16_t msg_id);
 
 // 4-байтовый идентификатор ключа (первые байты SHA-256 от симметричного ключа).
 std::array<uint8_t,4> keyId(const std::array<uint8_t,16>& key);

--- a/libs/key_transfer/key_transfer.h
+++ b/libs/key_transfer/key_transfer.h
@@ -44,7 +44,10 @@ struct FramePayload {
 const std::array<uint8_t,16>& rootKey();
 
 // Формирование нонса для обмена ключами (по упакованным метаданным и msg_id)
-std::array<uint8_t,12> makeNonce(uint32_t packed_meta, uint16_t msg_id);
+std::array<uint8_t,12> makeNonce(uint8_t version,
+                                 uint16_t frag_cnt,
+                                 uint32_t packed_meta,
+                                 uint16_t msg_id);
 
 // Подготовка кадра с публичным ключом: на выходе полный LoRa-кадр
 bool buildFrame(uint32_t msg_id,

--- a/serial_radio_control.ino
+++ b/serial_radio_control.ino
@@ -1697,7 +1697,7 @@ String cmdBcn() {
 // Команда ENCT повторяет тест шифрования и возвращает подробности
 String cmdEnct() {
   const uint8_t key[16]   = {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15};
-  auto nonce = KeyLoader::makeNonce(0, 0);
+  auto nonce = KeyLoader::makeNonce(0, 0, 0, 0);
   const char* text = "Test ENCT";
   size_t len = strlen(text);
   std::vector<uint8_t> cipher, tag, plain;


### PR DESCRIPTION
## Summary
- derive AEAD AAD/nonces from compact frame header data and 16-bit message ID across rx/tx modules and key transfer tooling
- update key loader/key transfer APIs to expose compact-header-based nonce generation and adjust callers, including CLI test
- ensure frame header copies are validated with version, and document new nonce signature

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68da2424173c8330b3ebfa1388acf800