### PR TITLE
Route Serial logs through logger

### DIFF
--- a/libs/key_loader/key_loader.cpp
+++ b/libs/key_loader/key_loader.cpp
@@ -645,7 +645,7 @@ bool ensureFlashEncryptionEnabled() {
   static bool warned = false;
   if (!enabled && !warned) {
     warned = true;
-    Serial.println(F("KeyLoader: Flash Encryption выключена, доступ к NVS запрещён"));
+    LOG_WARN("KeyLoader: Flash Encryption выключена, доступ к NVS запрещён");
   }
   return enabled;
 }
@@ -658,7 +658,7 @@ bool ensurePrefs() {
     }
     Preferences& prefs = prefsInstance();
     if (!prefs.begin("key_store", false)) {
-      Serial.println(F("KeyLoader: не удалось открыть раздел NVS"));
+      LOG_ERROR("KeyLoader: не удалось открыть раздел NVS");
       return false;
     }
     opened = true;
@@ -799,7 +799,7 @@ bool writeSnapshot(const StorageSnapshot& snapshot) {
   std::vector<uint8_t> blob = serializeSnapshot(snapshot);
   if (blob.empty()) {
 #ifdef ARDUINO
-    Serial.println(F("KeyLoader: ошибка сериализации snapshot"));
+    LOG_ERROR("KeyLoader: ошибка сериализации snapshot");
 #else
     std::cerr << "[KeyLoader] не удалось сериализовать snapshot" << std::endl;
 #endif
@@ -1155,11 +1155,11 @@ bool setPreferredBackend(StorageBackend backend) {
     g_preferred_backend = backend;
     return true;
   }
-  Serial.println(F("KeyLoader: доступен только бэкенд NVS"));
+  LOG_WARN("KeyLoader: доступен только бэкенд NVS");
   return false;
 #else
   (void)backend;
-  Serial.println(F("KeyLoader: на этой платформе нет доступного хранилища"));
+  LOG_ERROR("KeyLoader: на этой платформе нет доступного хранилища");
   return false;
 #endif
 #else

--- a/libs/serial_program_collector/serial_program_collector.cpp
+++ b/libs/serial_program_collector/serial_program_collector.cpp
@@ -13,13 +13,13 @@ bool collecting = false;
 void resetBuffer() {
   programBuffer = "";
   collecting = true;
-  Serial.println("Начат сбор программы");
+  LOG_INFO("Начат сбор программы");
 }
 
 // Добавление строки в общий буфер
 bool appendToBuffer(const String &line) {
   if (programBuffer.length() + line.length() + 1 > DefaultSettings::SERIAL_BUFFER_LIMIT) {
-    Serial.println("Буфер переполнен, приём остановлен");
+    LOG_ERROR("Буфер переполнен, приём остановлен");
     collecting = false;
     return false;
   }


### PR DESCRIPTION
## Summary
- replace Serial prints in serial_radio_control.ino with logging macros and formatted messages so they reach the debug log hook
- switch KeyLoader, SPIFFS guard, and serial program collector diagnostics to LOG_* to unify reporting levels
- add formatted hexdumps and combined status strings to avoid fragmented log records

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68da7e7576848330863b26855f9e4189