### PR TITLE
Fix SX1262 IRQ clearing access

### DIFF
--- a/radio_sx1262.h
+++ b/radio_sx1262.h
@@ -73,7 +73,14 @@ private:
   // Непосредственная установка частоты
   bool setFrequency(float freq);
 
-  SX1262 radio_;                         // экземпляр радиомодуля
+  // Вспомогательный класс для открытия доступа к защищённым методам SX1262
+  class PublicSX1262 : public SX1262 {
+  public:
+    using SX1262::SX1262;                // наследуем конструктор без изменений
+    using SX1262::clearIrqStatus;        // делаем очистку IRQ публичной
+  };
+
+  PublicSX1262 radio_;                   // экземпляр радиомодуля
   RxCallback rx_cb_;                     // пользовательский колбэк
   static RadioSX1262* instance_;         // указатель на текущий объект
   volatile bool packetReady_ = false;    // флаг готовности пакета


### PR DESCRIPTION
## Summary
- expose SX1262::clearIrqStatus through a thin wrapper so RadioSX1262 can reset IRQ flags

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da96d9e03483309592567b5e06b814