### PR TITLE
Refine serial logging aggregation

### DIFF
--- a/default_settings.h
+++ b/default_settings.h
@@ -90,7 +90,7 @@ namespace LogDetail {
   inline void logMsgVal(DefaultSettings::LogLevel level, const char* prefix, const T& val) {
     String full = String(prefix) + String(val);
     if (!shouldPrint(level, full)) return;
-    Serial.print(prefix); Serial.println(val);
+    Serial.println(full);
     Serial.flush();
     dispatch(level, full.c_str());
   }


### PR DESCRIPTION
## Summary
- ensure value logging on Arduino prints a single combined line so debug hooks receive the full message

## Testing
- not run (host environment only)


------
https://chatgpt.com/codex/tasks/task_e_68dae1ada9388330b7a5c19e8ac6558b