### PR TITLE
Fix IRQ status retrieval in RadioSX1262 handler

### DIFF
--- a/radio_sx1262.cpp
+++ b/radio_sx1262.cpp
@@ -334,13 +334,7 @@ void RadioSX1262::onDio1Static() {
 void RadioSX1262::handleDio1() {
   packetReady_ = true;                     // устанавливаем флаг готовности пакета
 
-  uint16_t irqStatus = 0;                     // текущее состояние IRQ
-  int16_t irqState = radio_.getIrqStatus(&irqStatus);
-  if (irqState != RADIOLIB_ERR_NONE) {        // проверяем результат чтения маски
-    LOG_WARN_VAL("RadioSX1262: не удалось прочитать IRQ статус, код=", irqState);
-    DEBUG_LOG("RadioSX1262: событие DIO1, модуль сообщает о готовности пакета");
-    return;                                   // при ошибке сохраняем прежнее поведение
-  }
+  uint16_t irqStatus = radio_.getIrqStatus(); // считываем текущее состояние IRQ
 
   struct FlagInfo {                        // описание интересующих флагов
     uint16_t mask;


### PR DESCRIPTION
## Summary
- update RadioSX1262::handleDio1 to use the new RadioLib IRQ status API

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dae93dfe288330989cdb16cfa43f40