### PR TITLE
Log SX1262 IRQ flags on DIO1 event

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,6 +626,8 @@ g++ -I. tests/test_key_transfer.cpp \
   режимом повышенного усиления приёмника.
 - `static uint16_t bankSize(ChannelBank bank)`, `static float bankRx(...)`, `static float bankTx(...)` —
   справочные методы.
+- `static void logIrqFlags(uint16_t flags)` — форматированный вывод активных IRQ-флагов радиочипа
+  в журнал.
 - `bool resetToDefaults()` — возврат параметров к значениям по умолчанию.
 
 ### SerialProgramCollector

--- a/radio_sx1262.h
+++ b/radio_sx1262.h
@@ -66,6 +66,9 @@ public:
   // Сброс параметров к значениям по умолчанию с перезапуском приёма
   bool resetToDefaults();
 
+  // Статический вывод активных флагов IRQ SX1262 в лог
+  static void logIrqFlags(uint16_t flags);
+
 private:
   static void onDio1Static();            // статический обработчик прерывания
   void handleDio1();                     // обработка приёма


### PR DESCRIPTION
## Summary
- read the SX1262 IRQ status in the DIO1 handler and log the active flags
- expose a reusable helper for formatting IRQ flags and document it in the README
- clear the IRQ status after handling so repeated events remain safe

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db4e55a980833089f70725f4ab072f