### PR TITLE
Fix RadioSX1262 IRQ handling for older RadioLib releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,7 +636,7 @@ g++ -I. tests/test_key_transfer.cpp \
   режимом повышенного усиления приёмника.
 - `static uint16_t bankSize(ChannelBank bank)`, `static float bankRx(...)`, `static float bankTx(...)` —
   справочные методы.
-- `static void logIrqFlags(RadioLibIrqFlags_t flags)` — форматированный вывод активных IRQ-флагов радиочипа
+- `static void logIrqFlags(uint32_t flags)` — форматированный вывод активных IRQ-флагов радиочипа
   в журнал.
 - `bool resetToDefaults()` — возврат параметров к значениям по умолчанию.
 

--- a/radio_sx1262.h
+++ b/radio_sx1262.h
@@ -67,7 +67,7 @@ public:
   bool resetToDefaults();
 
   // Статический вывод активных флагов IRQ SX1262 в лог
-  static void logIrqFlags(RadioLibIrqFlags_t flags);
+  static void logIrqFlags(uint32_t flags);
 
 private:
   static void onDio1Static();            // статический обработчик прерывания


### PR DESCRIPTION
## Summary
- detect RadioLib IRQ API at compile time to support both legacy and current SX1262 methods
- standardize logIrqFlags signature on uint32_t and update documentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbfc4e8f8483309d494a95e5f0acf7