### PR TITLE
Fix SX1262 IRQ handling across RadioLib versions

### DIFF
--- a/radio_sx1262.h
+++ b/radio_sx1262.h
@@ -76,7 +76,14 @@ private:
   // Непосредственная установка частоты
   bool setFrequency(float freq);
 
-  SX1262 radio_;                         // экземпляр радиомодуля
+  // Обёртка над SX1262 с публичным доступом к очистке IRQ-статуса
+  struct PublicSX1262 : public SX1262 {
+    using SX1262::SX1262;
+    using SX1262::clearIrqStatus;
+    using SX1262::getIrqStatus;
+  };
+
+  PublicSX1262 radio_;                   // экземпляр радиомодуля
   RxCallback rx_cb_;                     // пользовательский колбэк
   static RadioSX1262* instance_;         // указатель на текущий объект
   volatile bool packetReady_ = false;    // флаг готовности пакета


### PR DESCRIPTION
## Summary
- add SFINAE helpers to detect available RadioLib IRQ APIs at compile time
- expose SX1262::clearIrqStatus via a thin wrapper to allow legacy IRQ handling
- update DIO1 handler to support both flag- and status-based IRQ workflows

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dc096950e08330a987e552f5bde8e5