### PR TITLE
Add RadioLib IRQ compatibility wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,6 +639,9 @@ g++ -I. tests/test_key_transfer.cpp \
 - `static void logIrqFlags(uint32_t flags)` — форматированный вывод активных IRQ-флагов радиочипа
   в журнал.
 - `bool resetToDefaults()` — возврат параметров к значениям по умолчанию.
+- Вспомогательная обёртка `PublicSX1262` добавляет совместимые методы `getIrqFlags()`,
+  `clearIrqFlags(...)` и `getIrqStatus(uint16_t*)`, чтобы прошивка одинаково собиралась с разными
+  версиями RadioLib.
 
 ### SerialProgramCollector
 - `void resetBuffer()` — очистить буфер.

--- a/radio_sx1262.h
+++ b/radio_sx1262.h
@@ -81,6 +81,26 @@ private:
     using SX1262::SX1262;
     using SX1262::clearIrqStatus;
     using SX1262::getIrqStatus;
+
+    // Совместим интерфейсы RadioLib: новые обёртки сводятся к универсальным вызовам
+    uint16_t getIrqFlags() {
+      // РадиоLib в новых версиях возвращает флаги через getIrqFlags(),
+      // поэтому пробрасываем их через доступный getIrqStatus().
+      return SX1262::getIrqStatus();
+    }
+
+    int16_t clearIrqFlags(uint16_t /*mask*/) {
+      // Библиотека очищает все флаги сразу, поэтому игнорируем маску.
+      return SX1262::clearIrqStatus();
+    }
+
+    int16_t getIrqStatus(uint16_t* dest) {
+      // Старый интерфейс ожидал указатель: наполняем его и сообщаем об успехе.
+      if (dest) {
+        *dest = SX1262::getIrqStatus();
+      }
+      return RADIOLIB_ERR_NONE;
+    }
   };
 
   PublicSX1262 radio_;                   // экземпляр радиомодуля


### PR DESCRIPTION
## Summary
- добавить совместимые обёртки getIrqFlags/clearIrqFlags/getIrqStatus(uint16_t*) в PublicSX1262
- описать новые методы совместимости в README

## Testing
- not run (не запускались)


------
https://chatgpt.com/codex/tasks/task_e_68dc10e2cb448330b5200ab3c2e470df