### PR TITLE
Адаптация обработки IRQ SX1262 к RadioLib 7.3.0

### DIFF
--- a/radio_sx1262.cpp
+++ b/radio_sx1262.cpp
@@ -7,40 +7,10 @@
 #include <type_traits>
 #include <utility>
 
-namespace {
-
-// Компиляторные признаки доступных вариантов API обработки IRQ в RadioLib
-template <typename T, typename = void>
-struct HasIrqFlagsApi : std::false_type {};
-
-template <typename T>
-struct HasIrqFlagsApi<
-    T,
-    std::void_t<decltype(std::declval<T&>().getIrqFlags()),
-                decltype(std::declval<T&>().clearIrqFlags(RADIOLIB_SX126X_IRQ_ALL))>>
-    : std::true_type {};
-
-template <typename T, typename = void>
-struct HasZeroArgIrqStatusApi : std::false_type {};
-
-template <typename T>
-struct HasZeroArgIrqStatusApi<
-    T,
-    std::void_t<decltype(std::declval<T&>().getIrqStatus())>> : std::true_type {};
-
-template <typename T, typename = void>
-struct HasPointerIrqStatusApi : std::false_type {};
-
-template <typename T>
-struct HasPointerIrqStatusApi<
-    T,
-    std::void_t<decltype(std::declval<T&>().getIrqStatus(static_cast<uint16_t*>(nullptr)))>>
-    : std::true_type {};
-
-template <typename T>
-struct AlwaysFalse : std::false_type {};
-
-} // namespace
+using radio_sx1262_detail::AlwaysFalse;
+using radio_sx1262_detail::HasIrqFlagsApi;
+using radio_sx1262_detail::HasPointerIrqStatusApi;
+using radio_sx1262_detail::HasZeroArgIrqStatusApi;
 
 RadioSX1262* RadioSX1262::instance_ = nullptr; // инициализация статического указателя
 


### PR DESCRIPTION
## Summary
- вынес детекторы вариантов IRQ-API RadioLib в заголовок и расширил PublicSX1262 универсальными обёртками
- обновил реализацию RadioSX1262 для использования единых признаков вместо локальных шаблонов

## Testing
- not run (не запускалось)


------
https://chatgpt.com/codex/tasks/task_e_68dc16415a988330b37fd83da866bbe5