### PR TITLE
Fix SerialMirror remapping for ESP32 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@
 | `key_loader`, `crypto/aes_ccm`, `key_transfer` | Работа с ключами, AES-CCM и обмен корневым ключом. |
 | `crypto/hkdf` | HKDF-SHA256 для вывода симметричных ключей и вспомогательных параметров. |
 | `simple_logger`, `serial_program_collector`, `text_converter` | Логирование, сборка команд, преобразование текста. |
+| `serial_mirror` | Зеркалирует вывод базового `Serial` в `LogHook` и сохраняет совместимость с конструкциями вида `while (!Serial)`. |
 
 Файл `libs_includes.cpp` подключает реализации библиотек для Arduino-проекта и избавляет от
 неявных зависимостей.

--- a/libs/serial_mirror/serial_mirror.cpp
+++ b/libs/serial_mirror/serial_mirror.cpp
@@ -85,6 +85,13 @@ HardwareSerial& SerialMirror::base() {
   return *serial_;
 }
 
+SerialMirror::operator bool() const {
+  if (!serial_) {
+    return false;  // Нет базового Serial — считаем интерфейс неинициализированным.
+  }
+  return static_cast<bool>(*serial_);
+}
+
 void SerialMirror::mirrorChar(uint8_t ch) {
   if (ch == '\r') {
     return; // пропускаем возврат каретки

--- a/libs/serial_mirror/serial_mirror.h
+++ b/libs/serial_mirror/serial_mirror.h
@@ -33,6 +33,9 @@ class SerialMirror : public Stream {
 
   HardwareSerial& base();
 
+  // Оператор приведения к bool для совместимости с конструкциями вида `while (!Serial)`.
+  explicit operator bool() const;
+
  private:
   HardwareSerial* serial_;
   String buffer_;
@@ -46,6 +49,9 @@ extern SerialMirror SerialDebug;
 #define SERIAL_MIRROR_ACTIVE 1
 
 #ifndef SERIAL_MIRROR_DISABLE_REMAP
+#ifdef Serial
+#undef Serial
+#endif
 #define Serial SerialDebug
 #endif
 


### PR DESCRIPTION
## Summary
- add a bool conversion operator to SerialMirror so `while (!Serial)` keeps working when remapped
- undefine the existing Serial macro before remapping to SerialDebug to avoid ESP32 warnings
- document the serial_mirror helper in the README library table

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dc24cb756c8330be3fe1f1a6f796fa