### PR TITLE
Guard KeyLoader flash encryption warning until Serial init

### DIFF
--- a/libs/key_loader/key_loader.cpp
+++ b/libs/key_loader/key_loader.cpp
@@ -644,8 +644,13 @@ bool ensureFlashEncryptionEnabled() {
   bool enabled = esp_flash_encryption_enabled();
   static bool warned = false;
   if (!enabled && !warned) {
-    warned = true;
-    Serial.println(F("KeyLoader: Flash Encryption выключена, доступ к NVS запрещён"));
+    // При старте глобальные конструкторы вызывают KeyLoader до инициализации Serial.
+    // Чтобы избежать аварии при обращении к неготовому UART, проверяем доступность
+    // Serial перед выводом предупреждения и повторяем попытку при следующем вызове.
+    if (Serial) {
+      warned = true;
+      Serial.println(F("KeyLoader: Flash Encryption выключена, доступ к NVS запрещён"));
+    }
   }
   return enabled;
 }


### PR DESCRIPTION
## Summary
- guard the Flash Encryption warning in KeyLoader so it only prints once the Serial port is ready, preventing crashes during early startup

## Testing
- not run (hardware-dependent)


------
https://chatgpt.com/codex/tasks/task_e_68dc2a75d59c83309eea2639d4b629da