### PR TITLE
Enable log hook buffering for host builds

### DIFF
--- a/libs/log_hook/log_hook.cpp
+++ b/libs/log_hook/log_hook.cpp
@@ -66,7 +66,103 @@ namespace LogHook {
 
   size_t size() {
     return gBuffer.size();
+}
+
+} // namespace LogHook
+
+#else  // !ARDUINO
+
+#include <deque>
+#include <mutex>
+#include <chrono>
+
+namespace {
+  // Максимальная ёмкость буфера журналирования для хостовой сборки
+  constexpr size_t kMaxEntries = 200;
+
+  std::deque<LogHook::Entry> gBuffer;       // кольцевой буфер последних строк
+  LogHook::Dispatcher gDispatcher = nullptr; // обработчик push-уведомлений
+  std::mutex gMutex;                         // защита общей памяти
+  uint32_t gNextId = 1;                      // последовательный идентификатор записей
+  const auto gStart = std::chrono::steady_clock::now(); // отметка старта процесса
+
+  // Расчёт значения uptime в миллисекундах от старта программы
+  uint32_t uptimeMs() {
+    using namespace std::chrono;
+    auto now = steady_clock::now();
+    auto diff = duration_cast<milliseconds>(now - gStart);
+    return static_cast<uint32_t>(diff.count());
   }
+
+  // Добавление строки в буфер с учётом ограничений по размеру
+  void pushEntry(const LogHook::LogString& text) {
+    LogHook::Entry entry{};
+    entry.id = gNextId++;
+    entry.text = text;
+    entry.uptime_ms = uptimeMs();
+
+    LogHook::Dispatcher dispatcherCopy;
+    {
+      std::lock_guard<std::mutex> lock(gMutex);
+      gBuffer.push_back(entry);
+      while (gBuffer.size() > kMaxEntries) {
+        gBuffer.pop_front();
+      }
+      dispatcherCopy = gDispatcher;
+    }
+
+    if (dispatcherCopy) {
+      dispatcherCopy(entry); // уведомляем подписчика вне блокировки
+    }
+  }
+} // namespace
+
+namespace LogHook {
+
+void setDispatcher(Dispatcher cb) {
+  std::lock_guard<std::mutex> lock(gMutex);
+  gDispatcher = std::move(cb);
+}
+
+void append(const LogString& line) {
+  pushEntry(line);
+}
+
+void append(const char* line) {
+  if (!line) {
+    pushEntry(LogString());
+  } else {
+    pushEntry(LogString(line));
+  }
+}
+
+std::vector<Entry> getRecent(size_t count) {
+  std::vector<Entry> out;
+  std::lock_guard<std::mutex> lock(gMutex);
+  if (count == 0 || gBuffer.empty()) {
+    return out;
+  }
+  if (count > gBuffer.size()) {
+    count = gBuffer.size();
+  }
+  out.reserve(count);
+  const size_t start = gBuffer.size() - count;
+  for (size_t i = start; i < gBuffer.size(); ++i) {
+    out.push_back(gBuffer[i]);
+  }
+  return out;
+}
+
+void clear() {
+  std::lock_guard<std::mutex> lock(gMutex);
+  gBuffer.clear();
+  gNextId = 1;
+}
+
+size_t size() {
+  std::lock_guard<std::mutex> lock(gMutex);
+  return gBuffer.size();
+}
 
 } // namespace LogHook
 

--- a/libs/log_hook/log_hook.h
+++ b/libs/log_hook/log_hook.h
@@ -14,6 +14,7 @@
 #  include <string>
 #  include <vector>
 #  include <utility>
+#  include <functional>
 #endif
 
 #include <vector>
@@ -23,7 +24,15 @@ namespace LogHook {
 #ifdef ARDUINO
   using LogString = String;  // На Arduino используем класс String
 #else
-  using LogString = std::string;  // Для хостовых сборок применяем std::string
+  using LogString = std::string;                // Для хостовых сборок применяем std::string
+#endif
+
+  struct Entry;  // предварительное объявление для типа диспетчера
+
+#ifdef ARDUINO
+  using Dispatcher = void(*)(const Entry&); // колбэк доставки новых сообщений
+#else
+  using Dispatcher = std::function<void(const Entry&)>; // диспетчер для push-уведомлений
 #endif
 
   // Структура одной записи журнала
@@ -32,9 +41,6 @@ namespace LogHook {
     LogString text;     // текст сообщения
     uint32_t uptime_ms; // время с момента старта устройства (millis)
   };
-
-#ifdef ARDUINO
-  using Dispatcher = void(*)(const Entry&); // колбэк доставки новых сообщений
 
   // Установка обработчика, который будет вызван при появлении новых записей
   void setDispatcher(Dispatcher cb);
@@ -51,15 +57,6 @@ namespace LogHook {
 
   // Возвращает текущий размер буфера
   size_t size();
-#else
-  // В хостовых сборках функции заглушены, чтобы не ломать тесты
-  inline void setDispatcher(void(*)(const Entry&)) {}
-  inline void append(const LogString&) {}
-  inline void append(const char*) {}
-  inline std::vector<Entry> getRecent(size_t) { return {}; }
-  inline void clear() {}
-  inline size_t size() { return 0; }
-#endif
 
 } // namespace LogHook
 #endif // LOG_HOOK_LOG_H


### PR DESCRIPTION
## Summary
- enable the LogHook buffer and dispatcher for non-Arduino builds so the web debug log shows entries again
- refactor the LogHook header to expose the same API on all platforms and keep Russian documentation intact

## Testing
- not run (reason: no automated tests provided)

------
https://chatgpt.com/codex/tasks/task_e_68dc38c2897083308e71ab8249f27979