### PR TITLE
Возврат отображения IRQ-флагов в debug-лог

### DIFF
--- a/default_settings.h
+++ b/default_settings.h
@@ -63,7 +63,11 @@ namespace LogDetail {
   inline bool shouldPrint(DefaultSettings::LogLevel level, const String& msg) {
     static String last;                                   // последнее выведенное сообщение
     if (!DefaultSettings::DEBUG || level > DefaultSettings::LOG_LEVEL) return false;
-    if (last == msg) return false;                        // пропускаем дубль
+    if (level == DefaultSettings::LogLevel::DEBUG) {      // для DEBUG всегда разрешаем вывод
+      last = msg;                                         // сохраняем сообщение для консистентности
+      return true;
+    }
+    if (last == msg) return false;                        // пропускаем дубль для уровней выше DEBUG
     last = msg;
     return true;
   }
@@ -112,7 +116,11 @@ namespace LogDetail {
   inline bool shouldPrint(DefaultSettings::LogLevel level, const std::string& msg) {
     static std::string last;                              // последнее выведенное сообщение
     if (!DefaultSettings::DEBUG || level > DefaultSettings::LOG_LEVEL) return false;
-    if (last == msg) return false;                        // пропускаем дубль
+    if (level == DefaultSettings::LogLevel::DEBUG) {      // для DEBUG не фильтруем повторяющиеся строки
+      last = msg;                                         // обновляем последнее сообщение
+      return true;
+    }
+    if (last == msg) return false;                        // пропускаем дубль для INFO/WARN/ERROR
     last = msg;
     return true;
   }


### PR DESCRIPTION
## Summary
- отключена фильтрация повторов для сообщений уровня DEBUG, чтобы восстановить вывод IRQ и других повторяющихся событий

## Testing
- not run (не запускалось)


------
https://chatgpt.com/codex/tasks/task_e_68dd070793e0833081bdcffb450a79a7