### PR TITLE
Добавлено отображение IRQ-флагов в журнале Debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,9 @@
 - Функции `enqueueLogEntry` и `flushPendingLogEntries` складывают новые строки в небольшую очередь
   и выгружают их в SSE-клиентов из `loop()`, избавляя USB-Serial от пауз при длительной отправке
   push-сообщений.
+- Функция `collectIrqFlagHints` в `web/script.js` выделяет активные IRQ-флаги SX1262 из строк вида
+  `RadioSX1262: IRQ=…` и сразу добавляет в журнал Debug пояснения (`IRQ_TX_DONE — передача пакета
+  завершена`, `IRQ_RX_DONE — пакет принят`, `IRQ_CRC_ERR — ошибка CRC` и т. д.).
 
 ## HTTP API
 - `POST /api/tx` — отправляет текст через `TxModule` (используется кнопкой «Отправить по радио»).

--- a/tests/web_ui/web_ui.test.js
+++ b/tests/web_ui/web_ui.test.js
@@ -317,3 +317,24 @@ test('debugLog создаёт элементы для каждого типа с
 
   assert.equal(debugRoot.children.length, debugLogSamples.length);
 });
+
+// Проверяем добавление расшифровок флагов IRQ SX1262
+test('debugLog показывает подсказки по IRQ-флагам', () => {
+  const { context: logCtx, document: logDoc } = createWebContext();
+  const debugRoot = logDoc.createElement('div');
+  debugRoot.scrollHeight = 0;
+  logCtx.UI.els.debugLog = debugRoot;
+
+  const text = 'RadioSX1262: IRQ=0x0043, расшифровка: [TX_DONE | RX_DONE]';
+  const timestamp = Date.UTC(2024, 0, 1, 12, 0, 0);
+  logCtx.debugLog(text, { timestamp });
+
+  assert.equal(debugRoot.children.length, 1);
+  const node = debugRoot.children[0];
+  assert(node.textContent.includes(text));
+  assert.equal(node.children.length, 1);
+  const hints = node.children[0];
+  assert.equal(hints.className, 'debug-line__irq');
+  assert(hints.textContent.includes('IRQ_TX_DONE — передача пакета завершена'));
+  assert(hints.textContent.includes('IRQ_RX_DONE — пакет принят'));
+});

--- a/web/style.css
+++ b/web/style.css
@@ -1504,6 +1504,7 @@ tbody tr.selected-info td { font-weight:600; }
 .debug-line--error { color: color-mix(in oklab, var(--danger) 75%, var(--text) 25%); }
 .debug-line--warn { color: color-mix(in oklab, #facc15 70%, var(--text) 30%); }
 .debug-line--action { color: color-mix(in oklab, var(--accent) 70%, var(--text) 30%); }
+.debug-line__irq { font-size:.78rem; color: var(--muted); margin-top:.1rem; padding-left:1.2rem; }
 .debug-metrics { background: var(--panel-2); border:1px solid color-mix(in oklab, var(--panel-2) 70%, black 30%); border-radius:.9rem; padding:1rem; margin-bottom:1.5rem; }
 .debug-metrics__header { display:flex; align-items:center; justify-content:space-between; gap:.75rem; margin-bottom:1rem; }
 .debug-metrics__status { font-size:.9rem; color: var(--muted); }


### PR DESCRIPTION
## Summary
- добавлены пояснения для IRQ-флагов SX1262 в web/script.js и web/web_content.h
- оформлен отдельный стиль для блока с подсказками и обновлена документация в README
- расширены web-ui тесты покрытием отображения подсказок

## Testing
- node --test tests/web_ui/web_ui.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dd70af4e148330943304e51fae2d83