### PR TITLE
Improve UTF-8 handling in serial mirror logs

### DIFF
--- a/libs/serial_mirror/serial_mirror.cpp
+++ b/libs/serial_mirror/serial_mirror.cpp
@@ -4,13 +4,12 @@
 #if defined(ARDUINO)
 
 namespace {
-  // Проверка, содержит ли строка только печатные символы и пробелы/табуляции.
-  // Байты с установленным старшим битом считаем частью UTF-8 и разрешаем.
+  // Проверка, содержит ли строка только печатные ASCII-символы и пробелы/табуляции.
   bool isMostlyPrintable(const String& s) {
     for (size_t i = 0; i < s.length(); ++i) {
       unsigned char c = static_cast<unsigned char>(s.charAt(i));
       if (c == '\t') continue;
-      if (c < 0x20 || c == 0x7F) {
+      if (c >= 0x80 || c < 0x20 || c == 0x7F) {
         return false;
       }
     }
@@ -117,20 +116,25 @@ void SerialMirror::flushBufferToLog() {
     return;
   }
   bool printable = isMostlyPrintable(line);
-  if (!printable) {
-    // Отдельно проверяем наличие UTF-8-байтов, чтобы не переводить кириллицу в HEX.
-    for (size_t i = 0; i < line.length(); ++i) {
-      if (static_cast<unsigned char>(line.charAt(i)) >= 0x80) {
-        LogHook::append(line);
-        return;
-      }
+  bool has_utf8 = false;
+  for (size_t i = 0; i < line.length() && !has_utf8; ++i) {
+    if (static_cast<unsigned char>(line.charAt(i)) >= 0x80) {
+      has_utf8 = true;
     }
   }
   if (printable) {
     LogHook::append(line);
-  } else {
-    LogHook::append(toHexLine(line));
+    if (has_utf8) {
+      // Добавляем диагностическую запись с HEX-представлением для UTF-8, чтобы облегчить анализ.
+      LogHook::append(toHexLine(line));
+    }
+    return;
   }
+  if (has_utf8) {
+    // Оставляем читаемую строку и дополняем её шестнадцатеричным дампом.
+    LogHook::append(line);
+  }
+  LogHook::append(toHexLine(line));
 }
 
 SerialMirror SerialDebug(Serial);


### PR DESCRIPTION
## Summary
- treat bytes with the high bit set as non-printable in the serial mirror to trigger diagnostics
- log an additional hex dump for lines containing UTF-8 bytes while preserving the readable text

## Testing
- python - <<'PY' ...

------
https://chatgpt.com/codex/tasks/task_e_68dd7b1960b483308d1fb4872b55cd1a