### PR TITLE
Add manual IRQ log flush helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,6 +649,7 @@ g++ -I. tests/test_key_transfer.cpp \
   справочные методы.
 - `static void logIrqFlags(uint32_t flags)` — форматированный вывод активных IRQ-флагов радиочипа
   в журнал.
+- `void flushPendingIrqLog()` — обходной ручной вызов переноса и вывода отложенных IRQ-логов.
 - `bool resetToDefaults()` — возврат параметров к значениям по умолчанию.
 - Вспомогательная обёртка `PublicSX1262` добавляет совместимые методы `getIrqFlags()`,
   `clearIrqFlags(...)` и `getIrqStatus(uint16_t*)`, чтобы прошивка одинаково собиралась с разными

--- a/radio_sx1262.cpp
+++ b/radio_sx1262.cpp
@@ -416,6 +416,11 @@ void RadioSX1262::logIrqFlags(uint32_t flags) {
   DEBUG_LOG("%s", message);
 }
 
+void RadioSX1262::flushPendingIrqLog() {
+  // Обеспечиваем обходной ручной вызов переноса IRQ-логов из ISR в основной поток
+  processPendingIrqLog();
+}
+
 void RadioSX1262::handleDio1() {
   uint32_t irqFlags = radio_.getIrqFlags();  // универсальное чтение флагов IRQ
   pendingIrqFlags_ = irqFlags;               // сохраняем флаги для вывода в основном потоке
@@ -463,7 +468,7 @@ void RadioSX1262::processPendingIrqLog() {
 
 // Проверка флага готовности и чтение данных
 void RadioSX1262::loop() {
-  processPendingIrqLog();                  // отложенный вывод статусов IRQ
+  flushPendingIrqLog();                    // отложенный вывод статусов IRQ
   if (!packetReady_) {                      // пакет пока не готов
     return;
   }

--- a/radio_sx1262.h
+++ b/radio_sx1262.h
@@ -127,6 +127,8 @@ public:
 
   // Статический вывод активных флагов IRQ SX1262 в лог
   static void logIrqFlags(uint32_t flags);
+  // Принудительная проверка и вывод отложенных IRQ-логов (обходной вызов из внешнего кода)
+  void flushPendingIrqLog();
 
 private:
   static void onDio1Static();            // статический обработчик прерывания


### PR DESCRIPTION
## Summary
- add a public helper to flush pending SX1262 IRQ logs from external code
- document the new helper in the RadioSX1262 section of the README

## Testing
- make -C tests clean all *(fails: libsodium headers are not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7ec5712c83309b082e75bf31ade4