### PR TITLE
Перенос чтения IRQ SX1262 из ISR в основной поток

### DIFF
--- a/radio_sx1262.h
+++ b/radio_sx1262.h
@@ -199,6 +199,7 @@ private:
   RxCallback rx_cb_;                     // пользовательский колбэк
   static RadioSX1262* instance_;         // указатель на текущий объект
   volatile bool packetReady_ = false;    // флаг готовности пакета
+  volatile bool irqNeedsRead_ = false;   // требуется ли чтение IRQ-регистров в основном потоке
   volatile bool irqLogPending_ = false;  // требуется ли вывести отложенный лог IRQ
   volatile uint32_t pendingIrqFlags_ = 0;          // сохранённые флаги IRQ из ISR
   volatile int16_t pendingIrqClearState_ = RADIOLIB_ERR_NONE; // результат очистки IRQ


### PR DESCRIPTION
## Summary
- добавлен флаг irqNeedsRead_, чтобы переносить чтение и очистку IRQ SX1262 из ISR в основной поток
- обновлена обработка RadioSX1262::processPendingIrqLog для чтения регистров и логирования уже вне ISR

## Testing
- ctest (нет конфигурации тестов, команда завершается сообщением об отсутствии тестов)


------
https://chatgpt.com/codex/tasks/task_e_68dd88cc66208330a93f89b4ca2e4a3c