### PR TITLE
Restore Serial remap for mirrored logging

### DIFF
--- a/libs/serial_mirror/serial_mirror.cpp
+++ b/libs/serial_mirror/serial_mirror.cpp
@@ -139,5 +139,12 @@ void SerialMirror::flushBufferToLog() {
 
 SerialMirror SerialDebug(Serial);
 
+// Возвращаем действие переопределения Serial -> SerialDebug для остальных файлов.
+#undef SERIAL_MIRROR_DISABLE_REMAP
+#ifdef Serial
+#undef Serial
+#endif
+#define Serial SerialDebug
+
 #endif  // defined(ARDUINO)
 


### PR DESCRIPTION
## Summary
- restore the Serial -> SerialDebug macro after SerialMirror instantiation so other modules see the mirrored interface

## Testing
- not run (hardware-dependent verification required)

------
https://chatgpt.com/codex/tasks/task_e_68ddf6ef12208330b2ce711cb168ad84