### PR TITLE
Fix IRQ status detection for RadioSX1262 log messages

### DIFF
--- a/tests/web_ui/web_ui.test.js
+++ b/tests/web_ui/web_ui.test.js
@@ -133,6 +133,25 @@ test('formatChatImageCaption собирает подпись', () => {
   assert.equal(caption, 'img-1 · 1.5 КиБ · 320×240 · профиль S · отправка…');
 });
 
+// Проверяем, что обновление статуса IRQ срабатывает на сообщении без символов после IRQ
+test('debugLog сохраняет статус IRQ для сообщений RadioSX1262 без хвоста', () => {
+  const wrap = document.createElement('div');
+  const messageEl = document.createElement('span');
+  const metaEl = document.createElement('span');
+  wrap.classList.remove('active');
+  UI.els.chatIrqStatus = wrap;
+  UI.els.chatIrqMessage = messageEl;
+  UI.els.chatIrqMeta = metaEl;
+  UI.els.debugLog = document.createElement('div');
+
+  ctx.debugLog('RadioSX1262: событие DIO1 без активных флагов IRQ', { origin: 'device', uptimeMs: 1234 });
+
+  assert.equal(UI.state.irqStatus.message, 'RadioSX1262: событие DIO1 без активных флагов IRQ');
+  assert.equal(UI.state.irqStatus.uptimeMs, 1234);
+  assert.equal(wrap.classList.contains('active'), true);
+  assert.equal(messageEl.textContent, 'RadioSX1262: событие DIO1 без активных флагов IRQ');
+});
+
 // Проверяем эвристику читаемости текста
 test('evaluateTextCandidate и selectReadableTextCandidate выбирают кириллицу', () => {
   const good = ctx.evaluateTextCandidate('Привет, мир!');

--- a/web/script.js
+++ b/web/script.js
@@ -9124,7 +9124,7 @@ function debugLog(text, opts) {
   if (options.origin === "device") {
     const rawText = text != null ? String(text) : "";
     const lowered = rawText.toLowerCase();
-    if (rawText && (lowered.includes("irq=") || /\birq[-_\s]/i.test(rawText)) && (lowered.includes("radiosx1262") || lowered.includes("sx1262"))) {
+    if (rawText && (lowered.includes("irq=") || /\birq(?:[-_\s]|$)/i.test(rawText)) && (lowered.includes("radiosx1262") || lowered.includes("sx1262"))) {
       if (!UI.state.irqStatus || typeof UI.state.irqStatus !== "object") {
         UI.state.irqStatus = { message: "", uptimeMs: null, timestamp: null };
       }


### PR DESCRIPTION
## Summary
- expand the IRQ detection regex in the web debug logger to cover messages ending with "IRQ"
- add a web UI unit test that verifies the RadioSX1262 status is updated for such log entries

## Testing
- `node --test tests/web_ui/web_ui.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68de0f9fcc4c8330b0b8b25616dbf228