### PR TITLE
Нормализация ключей без кавычек в parseJsonLenient

### DIFF
--- a/web/script.js
+++ b/web/script.js
@@ -7675,6 +7675,10 @@ function parseJsonLenient(rawText) {
     .replace(/\/\*[\s\S]*?\*\//g, "") // убираем блочные комментарии
     .replace(/(^|[^:])\/\/.*$/gm, "$1"); // убираем построчные комментарии без трогания URL
   sanitized = sanitized.replace(/,\s*([}\]])/g, "$1"); // отрезаем висячие запятые
+  sanitized = sanitized.replace(/([\{,]\s*)([A-Za-z_][A-Za-z0-9_-]*)\s*:/g, (match, prefix, key) => {
+    // Аккуратно добавляем кавычки к необрамлённым идентификаторам ключей
+    return `${prefix}"${key}":`;
+  });
   sanitized = sanitized.replace(/([\{,]\s*)'([^'"\n]*)'\s*:/g, "$1\"$2\":"); // нормализуем ключи в кавычках
   sanitized = sanitized.replace(/:\s*'([^'"\n]*)'/g, ': "$1"'); // заменяем одиночные кавычки в значениях
   if (!sanitized.trim()) return null;


### PR DESCRIPTION
## Summary
- добавить автоматическое экранирование необрамленных идентификаторов ключей в parseJsonLenient
- сохранить прежние очистки JSON и не затрагивать значения с URL

## Testing
- node - <<'NODE'
const fs = require('fs');
const vm = require('vm');
const code = fs.readFileSync('web/script.js', 'utf8');
const sandbox = {
  console,
  note: ()=>{},
  status: ()=>{},
  UI: { key: {} },
  renderKeyState: ()=>{},
  debugLog: ()=>{},
  window: {},
  document: { addEventListener: ()=>{} },
  localStorage: { getItem: ()=>null, setItem: ()=>{}, removeItem: ()=>{} },
};
sandbox.window.document = sandbox.document;
sandbox.window.localStorage = sandbox.localStorage;
vm.createContext(sandbox);
vm.runInContext(code, sandbox);
const { parseJsonLenient } = sandbox;
const sample1 = '{foo: 1, url: "http://example.com"}';
console.log('sample1', parseJsonLenient(sample1));
const sample2 = '{bar_baz: "ok", nested: {inner_key: 2}}';
console.log('sample2', parseJsonLenient(sample2));
const sample3 = '{"already": "quoted", keep: "value:with:colons"}';
console.log('sample3', parseJsonLenient(sample3));
NODE

------
https://chatgpt.com/codex/tasks/task_e_68de2ff29cc88330b76a92812de5f842