### PR TITLE
Добавлена условная проверка занятости канала SX1262

### DIFF
--- a/radio_sx1262.cpp
+++ b/radio_sx1262.cpp
@@ -285,7 +285,14 @@ bool RadioSX1262::startReceiveWithRetry(const char* context) {
                   static_cast<unsigned>(attempt), ctx);
     LOG_ERROR_VAL(prefix, state);                          // фиксируем код ошибки
     lastError_ = state;                                    // сохраняем код для внешнего запроса
-    if (state == RADIOLIB_ERR_CHANNEL_BUSY) {              // канал занят — выполняем программный сброс
+#if defined(RADIOLIB_ERR_CHANNEL_BUSY)
+    const bool channelBusy = (state == RADIOLIB_ERR_CHANNEL_BUSY);
+#elif defined(RADIOLIB_ERR_CHANNEL_BUSY_LBT)
+    const bool channelBusy = (state == RADIOLIB_ERR_CHANNEL_BUSY_LBT);
+#else
+    const bool channelBusy = false;
+#endif
+    if (channelBusy) {                                      // канал занят — выполняем программный сброс
       const int16_t resetState = radio_.reset();
       if (resetState != RADIOLIB_ERR_NONE) {
         LOG_WARN_VAL("RadioSX1262: программный сброс после занятого канала вернул код=", resetState);


### PR DESCRIPTION
## Summary
- обработал отсутствие константы `RADIOLIB_ERR_CHANNEL_BUSY`, используя условную компиляцию
- сохранил логику программного сброса при занятом канале для библиотек, где код ошибки доступен

## Testing
- not run (не указан доступный способ проверки)

------
https://chatgpt.com/codex/tasks/task_e_68de534e83e483308ab8d8716230a854