### PR TITLE
Добавлены модульные тесты логирования IRQ RadioSX1262

### DIFF
--- a/README.md
+++ b/README.md
@@ -939,6 +939,12 @@ rs255223::decode -> PacketGatherer -> обработка сообщения
   ./tests/build/test_key_transfer
   ```
   При необходимости можно указать другой набор исходников, передав `TEST_SRCS="test_key_transfer.cpp test_enct.cpp"`.
+- Для проверки форматирования IRQ-логов радиомодуля подготовлен отдельный тест:
+  ```bash
+  make -C tests build/test_radio_irq_logging
+  ./tests/build/test_radio_irq_logging
+  ```
+  Заглушки для Arduino/RadioLib подключаются автоматически, поэтому аппаратное окружение не требуется.
 - Комплексный тест полного цикла без радиоканала по-прежнему можно собрать напрямую:
   ```bash
   g++ -I. -I.. tests/test_processing_without_send.cpp tx_module.cpp rx_module.cpp \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,18 +1,19 @@
 # Простой Makefile для сборки тестов с учётом зависимостей модулей
 CXX ?= g++
 CXXFLAGS ?= -std=c++17 -Wall -Wextra -Wpedantic
-CPPFLAGS ?= -I.. -I../libs
+CPPFLAGS ?= -I.. -I../libs -I./stubs -I../src
 LDFLAGS ?=
 LDLIBS ?= -lsodium
 
 BUILD_DIR ?= build
 
-SUPPORT_SRCS := ../libs_includes.cpp \
-                ../message_buffer.cpp \
-                ../tx_module.cpp \
-                ../rx_module.cpp
+SUPPORT_SRCS := ../src/libs_includes.cpp \
+                ../src/message_buffer.cpp \
+                ../src/tx_module.cpp \
+                ../src/rx_module.cpp \
+                ../src/radio_sx1262.cpp
 SUPPORT_OBJS := $(patsubst ../%.cpp,$(BUILD_DIR)/support/%.o,$(SUPPORT_SRCS))
-TEST_SRCS ?= test_key_transfer.cpp
+TEST_SRCS ?= test_key_transfer.cpp test_radio_irq_logging.cpp
 TEST_BINS := $(patsubst %.cpp,$(BUILD_DIR)/%,$(TEST_SRCS))
 TEST_TARGETS := $(patsubst %.cpp,%,$(TEST_SRCS))
 

--- a/tests/stubs/Arduino.h
+++ b/tests/stubs/Arduino.h
@@ -1,0 +1,21 @@
+#pragma once
+// Заглушка Arduino API для хостовых модульных тестов без аппаратуры
+#include <cstdint>
+
+namespace ArduinoStub {
+// Значения виртуального времени в милли- и микросекундах
+inline uint32_t gMillis = 0;
+inline uint32_t gMicros = 0;
+}
+
+inline uint32_t millis() { return ArduinoStub::gMillis; }
+inline uint32_t micros() { return ArduinoStub::gMicros; }
+inline void delay(unsigned long) {}
+inline void delayMicroseconds(unsigned int) {}
+inline void yield() {}
+inline void pinMode(int, int) {}
+inline void digitalWrite(int, int) {}
+inline void attachInterrupt(int, void (*)(void), int) {}
+inline void detachInterrupt(int) {}
+inline void noInterrupts() {}
+inline void interrupts() {}

--- a/tests/stubs/RadioLib.h
+++ b/tests/stubs/RadioLib.h
@@ -1,0 +1,75 @@
+#pragma once
+// Заглушка RadioLib для модульных тестов, исключающая обращение к реальному железу
+#include <cstddef>
+#include <cstdint>
+
+// Константы статусов и флагов IRQ, используемые в прошивке
+#define RADIOLIB_ERR_NONE 0
+#define RADIOLIB_ERR_CHANNEL_BUSY -16
+#define RADIOLIB_ERR_CHANNEL_BUSY_LBT -17
+#define RADIOLIB_SX126X_IRQ_NONE 0x0000U
+#define RADIOLIB_SX126X_IRQ_ALL 0xFFFFU
+#define RADIOLIB_SX126X_IRQ_TX_DONE 0x0001U
+#define RADIOLIB_SX126X_IRQ_RX_DONE 0x0002U
+#define RADIOLIB_SX126X_IRQ_PREAMBLE_DETECTED 0x0004U
+#define RADIOLIB_SX126X_IRQ_SYNC_WORD_VALID 0x0008U
+#define RADIOLIB_SX126X_IRQ_HEADER_VALID 0x0010U
+#define RADIOLIB_SX126X_IRQ_HEADER_ERR 0x0020U
+#define RADIOLIB_SX126X_IRQ_CRC_ERR 0x0040U
+#define RADIOLIB_SX126X_IRQ_TIMEOUT 0x0080U
+#define RADIOLIB_IRQ_RX_TIMEOUT 0x0100U
+#define RADIOLIB_IRQ_TX_TIMEOUT 0x0200U
+#define RADIOLIB_SX126X_IRQ_CAD_DONE 0x0400U
+#define RADIOLIB_SX126X_IRQ_CAD_DETECTED 0x0800U
+
+class Module {
+public:
+  Module(int, int, int, int) {}
+};
+
+// Минимальная заглушка SX1262, предоставляющая доступ к состоянию через публичные поля
+class SX1262 {
+public:
+  explicit SX1262(Module* module) : module_(module) {}
+
+  int16_t begin(float, float, int, int, uint8_t, int8_t, uint16_t, float, bool) {
+    (void)module_;
+    return RADIOLIB_ERR_NONE;
+  }
+
+  int16_t setFrequency(float) { return RADIOLIB_ERR_NONE; }
+  int16_t transmit(uint8_t*, size_t) { return RADIOLIB_ERR_NONE; }
+  size_t getPacketLength(bool = true) { return testPacketLength; }
+  int16_t readData(uint8_t*, size_t) { return testReadState; }
+  float getSNR() const { return testSnr; }
+  float getRSSI() const { return testRssi; }
+  uint8_t randomByte() { return nextRandom++; }
+  int16_t startReceive() { return RADIOLIB_ERR_NONE; }
+  int16_t reset() { return RADIOLIB_ERR_NONE; }
+  int16_t setBandwidth(float) { return RADIOLIB_ERR_NONE; }
+  int16_t setSpreadingFactor(int) { return RADIOLIB_ERR_NONE; }
+  int16_t setCodingRate(int) { return RADIOLIB_ERR_NONE; }
+  int16_t setOutputPower(int8_t) { return RADIOLIB_ERR_NONE; }
+  int16_t setRxBoostedGainMode(bool, bool) { return RADIOLIB_ERR_NONE; }
+  void setDio1Action(void (*)(void)) {}
+  uint32_t getIrqFlags() { return testIrqFlags; }
+  int16_t clearIrqFlags(uint32_t) { return testClearIrqState; }
+  uint16_t getIrqStatus() { return static_cast<uint16_t>(testIrqFlags); }
+  int16_t getIrqStatus(uint16_t* dest) {
+    if (dest) {
+      *dest = static_cast<uint16_t>(testIrqFlags);
+    }
+    return RADIOLIB_ERR_NONE;
+  }
+  int16_t clearIrqStatus() { return testClearIrqState; }
+
+  Module* module_;
+  uint32_t testIrqFlags = 0;
+  int16_t testClearIrqState = RADIOLIB_ERR_NONE;
+  size_t testPacketLength = 0;
+  int16_t testReadState = RADIOLIB_ERR_NONE;
+  float testSnr = 0.0f;
+  float testRssi = 0.0f;
+  uint8_t nextRandom = 0;
+};
+

--- a/tests/test_radio_irq_logging.cpp
+++ b/tests/test_radio_irq_logging.cpp
@@ -1,0 +1,76 @@
+#include <cassert>
+#include <string>
+#include <iostream>
+
+// Разрешаем доступ к внутренним полям для настройки заглушек
+#define private public
+#define protected public
+#include "../src/radio_sx1262.h"
+#undef private
+#undef protected
+
+#include "../src/default_settings.h"  // макросы логирования
+#include "../src/libs/log_hook/log_hook.h"
+#include "stubs/Arduino.h"
+
+// Глобальные переменные для фиксации результата колбэка
+namespace {
+std::string gCallbackMessage;
+uint32_t gCallbackUptime = 0;
+
+void captureIrqLog(const char* message, uint32_t uptime) {
+  gCallbackMessage = message ? message : std::string();
+  gCallbackUptime = uptime;
+}
+}
+
+int main() {
+  // Проверяем статический формат вывода с новым RX/TX timeout
+  LogHook::clear();
+  const uint32_t combinedFlags = RADIOLIB_SX126X_IRQ_RX_DONE |
+                                 RADIOLIB_IRQ_RX_TIMEOUT |
+                                 RADIOLIB_IRQ_TX_TIMEOUT;
+  RadioSX1262::logIrqFlags(combinedFlags);
+  auto logs = LogHook::getRecent(1);
+  assert(logs.size() == 1);
+  const std::string& combinedMessage = logs[0].text;
+  assert(combinedMessage.find("RadioSX1262: IRQ=0x0302") == 0);
+  assert(combinedMessage.find("IRQ_RX_DONE – пакет принят") != std::string::npos);
+  assert(combinedMessage.find("IRQ_RX_TIMEOUT – истёк таймаут ожидания приёма") !=
+         std::string::npos);
+  assert(combinedMessage.find("IRQ_TX_TIMEOUT – истёк таймаут ") != std::string::npos);
+
+  // Проверяем перенос отложенных логов и работу колбэка для таймаута TX
+  LogHook::clear();
+  gCallbackMessage.clear();
+  gCallbackUptime = 0;
+  ArduinoStub::gMillis = 123456;
+
+  RadioSX1262 radio;
+  radio.setIrqLogCallback(&captureIrqLog);
+  radio.radio_.testIrqFlags = RADIOLIB_IRQ_TX_TIMEOUT;
+  radio.radio_.testClearIrqState = RADIOLIB_ERR_NONE;
+  radio.irqNeedsRead_ = true;
+  radio.irqLogPending_ = true;
+
+  radio.processPendingIrqLog();
+
+  auto processedLogs = LogHook::getRecent(2);
+  bool found = false;
+  std::string capturedMessage;
+  for (const auto& entry : processedLogs) {
+    if (entry.text.find("RadioSX1262: IRQ=0x0200") == 0 &&
+        entry.text.find("IRQ_TX_TIMEOUT – истёк таймаут ") !=
+            std::string::npos) {
+      found = true;
+      capturedMessage = entry.text;
+      break;
+    }
+  }
+  assert(found);
+  assert(gCallbackMessage == capturedMessage);
+  assert(gCallbackUptime == ArduinoStub::gMillis);
+
+  std::cout << "Все проверки IRQ-логов RadioSX1262 успешно пройдены" << std::endl;
+  return 0;
+}


### PR DESCRIPTION
## Summary
- добавлены заглушки Arduino и RadioLib для хостовых модульных тестов RadioSX1262
- реализован тест `test_radio_irq_logging.cpp`, проверяющий формат логов и обработку RX/TX timeout
- обновлён tests/Makefile и README с инструкциями по сборке и запуску нового теста

## Testing
- make build/test_radio_irq_logging
- build/test_radio_irq_logging

------
https://chatgpt.com/codex/tasks/task_e_68df3a60ac548330b55b036b9736ee03