### PR TITLE
Ensure SX1262 returns to RX after transmission failure

### DIFF
--- a/src/radio_sx1262.cpp
+++ b/src/radio_sx1262.cpp
@@ -144,6 +144,8 @@ void RadioSX1262::send(const uint8_t* data, size_t len) {
   if (state != RADIOLIB_ERR_NONE) {          // проверка кода ошибки
     lastError_ = state;                      // сохраняем код сбоя
     LOG_ERROR_VAL("RadioSX1262: ошибка передачи, код=", state);
+    radio_.setFrequency(freq_rx);            // возвращаемся на частоту приёма после сбоя
+    startReceiveWithRetry("send: возврат к приёму после ошибки передачи");
     return;                                  // выходим без смены частоты
   }
   lastError_ = RADIOLIB_ERR_NONE;            // предыдущая операция прошла успешно

--- a/src/radio_sx1262.h
+++ b/src/radio_sx1262.h
@@ -203,6 +203,7 @@ private:
     }
   };
 
+  friend class RadioSX1262TestAccessor;       // тестовый доступ к внутренностям
   PublicSX1262 radio_;                   // экземпляр радиомодуля
   RxCallback rx_cb_;                     // пользовательский колбэк
   IrqLogCallback irqCallback_ = nullptr; // внешнее уведомление об IRQ-логе

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,7 +13,7 @@ SUPPORT_SRCS := ../src/libs_includes.cpp \
                 ../src/rx_module.cpp \
                 ../src/radio_sx1262.cpp
 SUPPORT_OBJS := $(patsubst ../%.cpp,$(BUILD_DIR)/support/%.o,$(SUPPORT_SRCS))
-TEST_SRCS ?= test_key_transfer.cpp test_radio_irq_logging.cpp
+TEST_SRCS ?= test_key_transfer.cpp test_radio_irq_logging.cpp test_radio_send_error_recovery.cpp
 TEST_BINS := $(patsubst %.cpp,$(BUILD_DIR)/%,$(TEST_SRCS))
 TEST_TARGETS := $(patsubst %.cpp,%,$(TEST_SRCS))
 

--- a/tests/stubs/RadioLib.h
+++ b/tests/stubs/RadioLib.h
@@ -37,14 +37,26 @@ public:
     return RADIOLIB_ERR_NONE;
   }
 
-  int16_t setFrequency(float) { return RADIOLIB_ERR_NONE; }
-  int16_t transmit(uint8_t*, size_t) { return RADIOLIB_ERR_NONE; }
+  int16_t setFrequency(float freq) {
+    previousSetFrequency = lastSetFrequency; // запоминаем предыдущую частоту
+    lastSetFrequency = freq;          // фиксируем установленную частоту
+    ++setFrequencyCalls;              // считаем вызовы смены частоты
+    return setFrequencyState;
+  }
+  int16_t transmit(uint8_t*, size_t len) {
+    lastTransmitLength = len;         // сохраняем длину последней передачи
+    ++transmitCalls;                  // считаем количество передач
+    return transmitResult;
+  }
   size_t getPacketLength(bool = true) { return testPacketLength; }
   int16_t readData(uint8_t*, size_t) { return testReadState; }
   float getSNR() const { return testSnr; }
   float getRSSI() const { return testRssi; }
   uint8_t randomByte() { return nextRandom++; }
-  int16_t startReceive() { return RADIOLIB_ERR_NONE; }
+  int16_t startReceive() {
+    ++startReceiveCalls;              // учитываем попытки запуска приёма
+    return startReceiveState;
+  }
   int16_t reset() { return RADIOLIB_ERR_NONE; }
   int16_t setBandwidth(float) { return RADIOLIB_ERR_NONE; }
   int16_t setSpreadingFactor(int) { return RADIOLIB_ERR_NONE; }
@@ -64,6 +76,15 @@ public:
   int16_t clearIrqStatus() { return testClearIrqState; }
 
   Module* module_;
+  float lastSetFrequency = 0.0f;       // последняя установленная частота
+  float previousSetFrequency = 0.0f;   // частота из предыдущего вызова setFrequency()
+  size_t setFrequencyCalls = 0;        // количество вызовов setFrequency()
+  size_t startReceiveCalls = 0;        // количество вызовов startReceive()
+  size_t transmitCalls = 0;            // количество вызовов transmit()
+  size_t lastTransmitLength = 0;       // длина последней переданной полезной нагрузки
+  int16_t transmitResult = RADIOLIB_ERR_NONE; // код возврата transmit()
+  int16_t setFrequencyState = RADIOLIB_ERR_NONE; // код возврата setFrequency()
+  int16_t startReceiveState = RADIOLIB_ERR_NONE; // код возврата startReceive()
   uint32_t testIrqFlags = 0;
   int16_t testClearIrqState = RADIOLIB_ERR_NONE;
   size_t testPacketLength = 0;

--- a/tests/test_radio_send_error_recovery.cpp
+++ b/tests/test_radio_send_error_recovery.cpp
@@ -1,0 +1,53 @@
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+
+#include "radio_sx1262.h"
+#include "default_settings.h"
+
+// Вспомогательный класс, открывающий доступ к внутреннему SX1262 для тестов
+class RadioSX1262TestAccessor {
+public:
+  static RadioSX1262::PublicSX1262& rawRadio(RadioSX1262& radio) { return radio.radio_; }
+};
+
+int main() {
+  RadioSX1262 radio;
+  auto& raw = RadioSX1262TestAccessor::rawRadio(radio);
+
+  // Настраиваем заглушку на успешные операции начальной инициализации
+  raw.setFrequencyState = RADIOLIB_ERR_NONE;
+  raw.startReceiveState = RADIOLIB_ERR_NONE;
+  assert(radio.begin());
+
+  const float expectedRx = radio.getRxFrequency();
+  const float expectedTx = radio.getTxFrequency();
+
+  // Сбрасываем счётчики вызовов, чтобы отслеживать только действия send()
+  raw.lastSetFrequency = 0.0f;
+  raw.previousSetFrequency = 0.0f;
+  raw.setFrequencyCalls = 0;
+  raw.startReceiveCalls = 0;
+  raw.transmitCalls = 0;
+  raw.lastTransmitLength = 0;
+  const size_t initialStartReceive = raw.startReceiveCalls;
+
+  // Имитируем сбой передачи и проверяем восстановление режима приёма
+  raw.transmitResult = -123; // произвольный код ошибки RadioLib
+  const uint8_t payload[1] = {0x42};
+  radio.send(payload, sizeof(payload));
+
+  // После ошибки модуль обязан вернуться на приёмную частоту
+  assert(std::fabs(raw.lastSetFrequency - expectedRx) < 1e-3f);
+  // startReceive() должен быть вызван повторно для возврата в RX
+  assert(raw.startReceiveCalls > initialStartReceive);
+  // Перед ошибкой передача должна была переключиться на TX
+  assert(raw.setFrequencyCalls >= 2);
+  assert(std::fabs(raw.previousSetFrequency - expectedTx) < 1e-3f);
+  assert(raw.transmitCalls == 1);
+  assert(raw.lastTransmitLength == sizeof(payload));
+
+  std::cout << "OK" << std::endl;
+  return 0;
+}


### PR DESCRIPTION
## Summary
- restore the SX1262 receive frequency and restart RX whenever transmit() returns an error
- extend the RadioLib test stub and expose a friend accessor so tests can observe internal radio state
- add a regression test that emulates a transmit failure and ensure it is built with the existing test suite

## Testing
- make -C tests
- tests/build/test_radio_send_error_recovery
- tests/build/test_radio_irq_logging
- tests/build/test_key_transfer

------
https://chatgpt.com/codex/tasks/task_e_68df4c45e494833095b53d43a3e82e4b