### PR TITLE
Handle fragment preparation failure in TxModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,6 +688,10 @@ g++ -I. tests/test_key_transfer.cpp \
   частями одного сообщения.
 - Последовательность кодирования: `rs255223::encode()` → `byte_interleaver::interleave()` →
   `conv_codec::encodeBits()` → (опционально) `bit_interleaver::interleave()` → `scrambler::scramble()`.
+- `static void setEncryptOverrideForTests(TxModule::EncryptOverride fn)` и
+  `static void resetEncryptOverrideForTests()` — тестовый хук для подмены реализации
+  ChaCha20-Poly1305. Используется только в `src/tests`, чтобы эмулировать ошибки подготовки
+  фрагментов без переписывания производственного кода.
 
 ### RxModule
 - `void setCallback(RxModule::Callback cb)` — обработчик входящих данных.

--- a/src/tx_module.h
+++ b/src/tx_module.h
@@ -48,6 +48,15 @@ public:
   void prepareExternalSend();
   // Фиксация момента завершения прямой отправки, чтобы пауза применялась ко всем модулям
   void completeExternalSend();
+  // Тестовый хук для подмены функции шифрования (используется только в unit-тестах)
+  using EncryptOverride = bool (*)(const uint8_t* key, size_t key_len,
+                                   const uint8_t* nonce, size_t nonce_len,
+                                   const uint8_t* aad, size_t aad_len,
+                                   const uint8_t* input, size_t input_len,
+                                   std::vector<uint8_t>& output,
+                                   std::vector<uint8_t>& tag);
+  static void setEncryptOverrideForTests(EncryptOverride fn);
+  static void resetEncryptOverrideForTests();
 private:
   struct PreparedFragment {
     std::vector<uint8_t> payload;               // кодированный фрагмент


### PR DESCRIPTION
## Summary
- abort TxModule fragment preparation when size checks or encryption fail and add a test hook to swap the AEAD implementation during unit tests
- extend the TxModule test to emulate an encryption failure, verify that loop() does not send frames until recovery, and document the new hook in the README

## Testing
- TEST_SRCS="$(cd src/tests && printf '%s ' test_*.cpp)" make -C src/tests
- for bin in src/tests/build/test_*; do echo "Running ${bin}"; "${bin}" > /tmp/test_run.log 2>&1 || { cat /tmp/test_run.log; exit 1; }; tail -n 2 /tmp/test_run.log; done


------
https://chatgpt.com/codex/tasks/task_e_68df4e571d588330b0be8f1a055f7648