### PR TITLE
Prevent blocking RX dump when Serial host absent

### DIFF
--- a/src/default_settings.h
+++ b/src/default_settings.h
@@ -44,6 +44,7 @@ namespace DefaultSettings {
   constexpr const char* WIFI_PASS = "12345678";    // пароль точки доступа
   constexpr bool DEBUG = true;                    // Флаг отладочного вывода
   constexpr bool SERIAL_FLUSH_AFTER_LOG = false;  // Принудительный Serial.flush() после каждой строки
+  constexpr bool RX_SERIAL_DUMP_ENABLED = true;   // Включение текстового дампа входящих пакетов в Serial при наличии хоста
   // Уровни журналирования для фильтрации сообщений
   enum class LogLevel : uint8_t { ERROR = 0, WARN = 1, INFO = 2, DEBUG = 3 };
   constexpr LogLevel LOG_LEVEL = LogLevel::DEBUG;   // Текущий уровень вывода


### PR DESCRIPTION
## Summary
- add a DefaultSettings toggle that allows disabling Serial RX dumps when USB is unavailable
- guard the RX callback so that Serial output is skipped unless the host connection has writable capacity

## Testing
- pio run -e esp32dev *(fails: command not found)*
- make -C tests test_large_packet_capacity *(fails: missing packetizer/packet_splitter.h include when building host tests)*

------
https://chatgpt.com/codex/tasks/task_e_68df56379b788330b698863bcc6e4a8d