### PR TITLE
Добавлен прокси availableForWrite для SerialMirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Arduino IDE и вспомогательных скриптов.
 | `key_loader`, `crypto/aes_ccm`, `key_transfer` | Работа с ключами, AES-CCM и обмен корневым ключом. |
 | `crypto/hkdf` | HKDF-SHA256 для вывода симметричных ключей и вспомогательных параметров. |
 | `simple_logger`, `serial_program_collector`, `text_converter` | Логирование, сборка команд, преобразование текста. |
-| `serial_mirror` | Зеркалирует вывод базового `Serial` в `LogHook` и сохраняет совместимость с конструкциями вида `while (!Serial)`. |
+| `serial_mirror` | Зеркалирует вывод базового `Serial` в `LogHook`, предоставляет метод `availableForWrite()` и сохраняет совместимость с конструкциями вида `while (!Serial)`. |
 | `config_loader` | Читает файл `config/default.ini`, подставляет значения по умолчанию и предоставляет доступ к структуре настроек. |
 
 Файл `libs_includes.cpp` подключает реализации библиотек для Arduino-проекта и избавляет от

--- a/lib/serial_mirror/serial_mirror.cpp
+++ b/lib/serial_mirror/serial_mirror.cpp
@@ -60,6 +60,10 @@ size_t SerialMirror::write(const uint8_t* buffer, size_t size) {
   return serial_->write(buffer, size);
 }
 
+int SerialMirror::availableForWrite() {
+  return serial_ ? static_cast<int>(serial_->availableForWrite()) : 0;
+}
+
 int SerialMirror::available() {
   return serial_ ? serial_->available() : 0;
 }

--- a/lib/serial_mirror/serial_mirror.h
+++ b/lib/serial_mirror/serial_mirror.h
@@ -24,6 +24,7 @@ class SerialMirror : public Stream {
   size_t write(uint8_t ch) override;
   size_t write(const uint8_t* buffer, size_t size) override;
 
+  int availableForWrite() override;
   int available() override;
   int read() override;
   int peek() override;

--- a/src/libs/serial_mirror/serial_mirror.cpp
+++ b/src/libs/serial_mirror/serial_mirror.cpp
@@ -60,6 +60,10 @@ size_t SerialMirror::write(const uint8_t* buffer, size_t size) {
   return serial_->write(buffer, size);
 }
 
+int SerialMirror::availableForWrite() {
+  return serial_ ? static_cast<int>(serial_->availableForWrite()) : 0;
+}
+
 int SerialMirror::available() {
   return serial_ ? serial_->available() : 0;
 }

--- a/src/libs/serial_mirror/serial_mirror.h
+++ b/src/libs/serial_mirror/serial_mirror.h
@@ -24,6 +24,7 @@ class SerialMirror : public Stream {
   size_t write(uint8_t ch) override;
   size_t write(const uint8_t* buffer, size_t size) override;
 
+  int availableForWrite() override;
   int available() override;
   int read() override;
   int peek() override;


### PR DESCRIPTION
## Описание
- добавлен метод `availableForWrite()` в зеркальный Serial как в каталоге `src`, так и в библиотечной копии `lib`
- реализован прокси-вызов к `HardwareSerial::availableForWrite()` с защитой от отсутствия базового Serial
- обновлена документация, чтобы отразить наличие нового метода в `serial_mirror`

## Тестирование
- `pio run` *(ошибка: команда недоступна в окружении контейнера)*

------
https://chatgpt.com/codex/tasks/task_e_68df635b04b08330bcd945af1d587c2d