### PR TITLE
Fix SerialMirror availableForWrite delegation

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Arduino IDE и вспомогательных скриптов.
 | `key_loader`, `crypto/aes_ccm`, `key_transfer` | Работа с ключами, AES-CCM и обмен корневым ключом. |
 | `crypto/hkdf` | HKDF-SHA256 для вывода симметричных ключей и вспомогательных параметров. |
 | `simple_logger`, `serial_program_collector`, `text_converter` | Логирование, сборка команд, преобразование текста. |
-| `serial_mirror` | Зеркалирует вывод базового `Serial` в `LogHook`, предоставляет метод `availableForWrite()` и сохраняет совместимость с конструкциями вида `while (!Serial)`. |
+| `serial_mirror` | Зеркалирует вывод базового `Serial` в `LogHook`, предоставляет метод `availableForWrite()`, который напрямую делегирует `HardwareSerial::availableForWrite()` и сохраняет совместимость с конструкциями вида `while (!Serial)`. |
 | `config_loader` | Читает файл `config/default.ini`, подставляет значения по умолчанию и предоставляет доступ к структуре настроек. |
 
 Файл `libs_includes.cpp` подключает реализации библиотек для Arduino-проекта и избавляет от

--- a/lib/serial_mirror/serial_mirror.cpp
+++ b/lib/serial_mirror/serial_mirror.cpp
@@ -61,7 +61,7 @@ size_t SerialMirror::write(const uint8_t* buffer, size_t size) {
 }
 
 int SerialMirror::availableForWrite() {
-  return serial_ ? static_cast<int>(serial_->availableForWrite()) : 0;
+  return serial_ ? serial_->availableForWrite() : 0;
 }
 
 int SerialMirror::available() {

--- a/src/libs/serial_mirror/serial_mirror.cpp
+++ b/src/libs/serial_mirror/serial_mirror.cpp
@@ -61,7 +61,7 @@ size_t SerialMirror::write(const uint8_t* buffer, size_t size) {
 }
 
 int SerialMirror::availableForWrite() {
-  return serial_ ? static_cast<int>(serial_->availableForWrite()) : 0;
+  return serial_ ? serial_->availableForWrite() : 0;
 }
 
 int SerialMirror::available() {


### PR DESCRIPTION
## Summary
- delegate SerialMirror::availableForWrite directly to the wrapped HardwareSerial in both library copies
- document the delegation behaviour in the README entry for the serial_mirror library

## Testing
- `pio run` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df6bd4e5748330be6819e367f42c0f