### PR TITLE
Обновить логирование KeyLoader для синхронизации с API

### DIFF
--- a/src/libs/key_loader/key_loader.h
+++ b/src/libs/key_loader/key_loader.h
@@ -5,6 +5,13 @@
 
 namespace KeyLoader {
 
+#ifdef ARDUINO
+class __FlashStringHelper;
+using LogCallback = bool (*)(const __FlashStringHelper* message);
+#else
+using LogCallback = bool (*)(const char* message);
+#endif
+
 // Доступные варианты хранилища ключей
 enum class StorageBackend : uint8_t {
   UNKNOWN = 0,  // режим автоопределения или отсутствие хранилища
@@ -115,6 +122,9 @@ bool hasEphemeralSession();
 
 // Сброс активной эпемерной пары (зануление приватного ключа).
 void endEphemeralSession();
+
+// Установка пользовательского обработчика логов KeyLoader.
+void setLogCallback(LogCallback callback);
 
 }  // namespace KeyLoader
 


### PR DESCRIPTION
## Summary
- добавлен общий тип LogCallback для Arduino и хостовых сборок, а также объявлена setLogCallback в заголовке
- реализована буферизация логов KeyLoader на прошивке с повторной доставкой через Serial и пользовательский колбэк
- переведены сообщения из прямого Serial.println на использование нового буфера и колбэка

## Testing
- make -C tests clean all *(fails: отсутствует заголовок libsodium в среде CI)*
- pio run *(fails: платформа PlatformIO не установлена в контейнере)*

------
https://chatgpt.com/codex/tasks/task_e_68df6d06494c8330a5ec3c1b9e75d935