### PR TITLE
Handle deferred KeyLoader logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,6 +836,8 @@ g++ -I. tests/test_key_transfer.cpp \
   доставке сообщения и `false`, если попытку требуется повторить позже (например, до появления USB).
   Тип `KeyLoader::LogCallback` на Arduino получает `const __FlashStringHelper*`, чтобы не копировать
   строки из PROGMEM, а в хостовых сборках принимает `const char*`.
+- `void flushBufferedLogs()` — вручную инициировать повторную попытку выгрузки буфера KeyLoader,
+  например, сразу после того как Serial стал доступен без перепривязки обработчика.
 
 ### `crypto/hkdf`
 - `Prk extract(const uint8_t* salt, size_t salt_len, const uint8_t* ikm, size_t ikm_len)` — стадия

--- a/lib/key_loader/key_loader.h
+++ b/lib/key_loader/key_loader.h
@@ -126,5 +126,8 @@ void endEphemeralSession();
 // Установка пользовательского обработчика логов KeyLoader.
 void setLogCallback(LogCallback callback);
 
+// Принудительно выгрузить буферизированные сообщения KeyLoader после появления Serial/обработчика.
+void flushBufferedLogs();
+
 }  // namespace KeyLoader
 

--- a/src/libs/key_loader/key_loader.h
+++ b/src/libs/key_loader/key_loader.h
@@ -129,5 +129,8 @@ void endEphemeralSession();
 // Установка пользовательского обработчика логов KeyLoader.
 void setLogCallback(LogCallback callback);
 
+// Принудительно выгрузить буферизированные сообщения KeyLoader после появления Serial/обработчика.
+void flushBufferedLogs();
+
 }  // namespace KeyLoader
 


### PR DESCRIPTION
## Summary
- добавлено отслеживание готовности Serial в основном цикле с вызовом принудительного сброса буфера KeyLoader
- расширен KeyLoader повторной попыткой вывода и новым методом `flushBufferedLogs()` в обеих версиях библиотеки
- задокументирована новая функция в README

## Testing
- `make -C tests test_keyloader` *(провалился: в окружении отсутствует lib sodium)*

------
https://chatgpt.com/codex/tasks/task_e_68df849e5420833096a3990637f39724