### PR TITLE
Асинхронное ожидание KEYTRANSFER RECEIVE

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,11 @@ Arduino IDE и вспомогательных скриптов.
 - Переключатель включает принудительное шифрование (даже для старых кадров без флага).
 - Кнопка `KEYTRANSFER SEND` копирует публичный ключ в буфер обмена (при поддержке API браузера);
   `KEYTRANSFER RECEIVE` сопровождается мигающим индикатором ожидания.
+- Неблокирующее ожидание `KEYTRANSFER RECEIVE` реализовано функциями `clearKeyReceivePollTimer`,
+  `resetKeyReceiveWaitState`, `updateKeyReceiveWaitMessage`, `scheduleKeyReceivePoll` и
+  `pollKeyTransferReceiveStatus` в `web/script.js`: первый ответ `status="waiting"` запускает
+  фоновый поллинг состояния, обновляет текст статуса и удерживает кнопку в режиме ожидания до
+  получения окончательного JSON.
 - Ответ `KEYSTATE` дополнительно содержит поля `baseKey`, `safeMode` и `storageReady`: базовый
   симметричный ключ (hex), признак защищённого режима и готовность хранилища.
 - Функция `parseJsonLenient` в `web/script.js` сначала пытается очистить и нормализовать ответ
@@ -792,6 +797,8 @@ g++ -I. tests/test_key_transfer.cpp \
 ### src/main.cpp
 - `String makeAccessPointSsid()` — формирует имя точки доступа с коротким суффиксом из уникального
   идентификатора устройства.
+- `void resetKeyTransferWaitTiming()` — сбрасывает временные отметки ожидания KEYTRANSFER, чтобы
+  повторный запрос начинался с корректных значений дедлайна после успеха, тайм-аута или ошибки.
 
 ### TextConverter
 - `std::vector<uint8_t> utf8ToCp1251(const std::string& in)` — UTF-8 → CP1251.


### PR DESCRIPTION
## Summary
- добавить сброс временных отметок ожидания и расширить JSON-ответ KEYTRANSFER состоянием остатка времени
- запустить неблокирующий цикл ожидания в loop() с прокруткой radio/tx и поддержкой push/SSE во время ожидания
- обновить web/script.js и README: асинхронный поллинг KEYTRANSFER RECEIVE с отображением прогресса и документированием новых функций

## Testing
- make -C tests test_keytransfer_receive_async *(не собрался: отсутствует lib sodium в окружении)*
- make -C tests test_sse_backpressure


------
https://chatgpt.com/codex/tasks/task_e_68df99263c7083308b83350d4bbb9c83