### PR TITLE
Guard Serial writes and maintain LogHook fallback

### DIFF
--- a/lib/simple_logger/simple_logger.cpp
+++ b/lib/simple_logger/simple_logger.cpp
@@ -41,16 +41,27 @@ void logStatus(const std::string& line) {
   std::string_view prefix_view = (pos == std::string::npos)
                                    ? std::string_view(line)
                                    : std::string_view(line.data(), pos);
+  bool serialReady = false;                        // отметка готовности аппаратного Serial
+#ifdef ARDUINO
+  serialReady = static_cast<bool>(Serial);
+#endif
+
   if (LogEntry* existing = findByPrefix(prefix_view)) {
     existing->line = line;                       // обновляем строку без перевыделения
 #ifdef ARDUINO
-    Serial.println(line.c_str());                // повторно выводим актуальную строку в Serial
-    if (DefaultSettings::SERIAL_FLUSH_AFTER_LOG) {
-      Serial.flush();
+    if (serialReady) {                           // не пишем в неготовый порт
+      Serial.println(line.c_str());              // повторно выводим актуальную строку в Serial
+      if (DefaultSettings::SERIAL_FLUSH_AFTER_LOG) {
+        Serial.flush();
+      }
     }
 #endif
 #if !(defined(SERIAL_MIRROR_ACTIVE) && SERIAL_MIRROR_ACTIVE)
     LogHook::append(line.c_str());               // дублируем в буфер push-логов
+#else
+    if (!serialReady) {                          // при отсутствии Serial отправляем через LogHook
+      LogHook::append(line.c_str());
+    }
 #endif
     return;
   }
@@ -67,13 +78,19 @@ void logStatus(const std::string& line) {
   entry.prefix.assign(prefix_view.data(), prefix_view.size());
   entry.line = line;
 #ifdef ARDUINO
-  Serial.println(line.c_str());                  // выводим новую запись в Serial
-  if (DefaultSettings::SERIAL_FLUSH_AFTER_LOG) {
-    Serial.flush();
+  if (serialReady) {                             // гарантируем готовность Serial перед выводом
+    Serial.println(line.c_str());                // выводим новую запись в Serial
+    if (DefaultSettings::SERIAL_FLUSH_AFTER_LOG) {
+      Serial.flush();
+    }
   }
 #endif
 #if !(defined(SERIAL_MIRROR_ACTIVE) && SERIAL_MIRROR_ACTIVE)
   LogHook::append(line.c_str());                 // передаём запись в веб-интерфейс
+#else
+  if (!serialReady) {                            // обеспечиваем доставку при отключённом Serial
+    LogHook::append(line.c_str());
+  }
 #endif
 }
 

--- a/src/libs/simple_logger/simple_logger.cpp
+++ b/src/libs/simple_logger/simple_logger.cpp
@@ -41,16 +41,27 @@ void logStatus(const std::string& line) {
   std::string_view prefix_view = (pos == std::string::npos)
                                    ? std::string_view(line)
                                    : std::string_view(line.data(), pos);
+  bool serialReady = false;                        // отметка готовности аппаратного Serial
+#ifdef ARDUINO
+  serialReady = static_cast<bool>(Serial);
+#endif
+
   if (LogEntry* existing = findByPrefix(prefix_view)) {
     existing->line = line;                       // обновляем строку без перевыделения
 #ifdef ARDUINO
-    Serial.println(line.c_str());                // повторно выводим актуальную строку в Serial
-    if (DefaultSettings::SERIAL_FLUSH_AFTER_LOG) {
-      Serial.flush();
+    if (serialReady) {                           // не пишем в неготовый порт
+      Serial.println(line.c_str());              // повторно выводим актуальную строку в Serial
+      if (DefaultSettings::SERIAL_FLUSH_AFTER_LOG) {
+        Serial.flush();
+      }
     }
 #endif
 #if !(defined(SERIAL_MIRROR_ACTIVE) && SERIAL_MIRROR_ACTIVE)
     LogHook::append(line.c_str());               // дублируем в буфер push-логов
+#else
+    if (!serialReady) {                          // при отсутствии Serial отправляем через LogHook
+      LogHook::append(line.c_str());
+    }
 #endif
     return;
   }
@@ -67,13 +78,19 @@ void logStatus(const std::string& line) {
   entry.prefix.assign(prefix_view.data(), prefix_view.size());
   entry.line = line;
 #ifdef ARDUINO
-  Serial.println(line.c_str());                  // выводим новую запись в Serial
-  if (DefaultSettings::SERIAL_FLUSH_AFTER_LOG) {
-    Serial.flush();
+  if (serialReady) {                             // гарантируем готовность Serial перед выводом
+    Serial.println(line.c_str());                // выводим новую запись в Serial
+    if (DefaultSettings::SERIAL_FLUSH_AFTER_LOG) {
+      Serial.flush();
+    }
   }
 #endif
 #if !(defined(SERIAL_MIRROR_ACTIVE) && SERIAL_MIRROR_ACTIVE)
   LogHook::append(line.c_str());                 // передаём запись в веб-интерфейс
+#else
+  if (!serialReady) {                            // обеспечиваем доставку при отключённом Serial
+    LogHook::append(line.c_str());
+  }
 #endif
 }
 


### PR DESCRIPTION
## Summary
- gate Serial.println/flush calls in SimpleLogger behind readiness checks to avoid blocking on unavailable ports
- keep LogHook delivery active even when Serial is missing so web logging continues

## Testing
- make -C tests build/test_sse_backpressure

------
https://chatgpt.com/codex/tasks/task_e_68df9ccd9f708330973c8ba0c8e1eaac