### PR TITLE
Fix incorrect TX frequency in home bank

### DIFF
--- a/src/libs/radio/frequency_tables.h
+++ b/src/libs/radio/frequency_tables.h
@@ -108,7 +108,7 @@ inline constexpr std::size_t HOME_BANK_SIZE = 7;
 inline constexpr float RX_HOME[HOME_BANK_SIZE] = {
     263.450F, 257.700F, 257.200F, 256.450F, 267.250F, 250.090F, 249.850F};
 inline constexpr float TX_HOME[HOME_BANK_SIZE] = {
-    311.400F, 316.150F, 308.800F, 398.800F, 308.250F, 312.600F, 298.830F};
+    311.400F, 316.150F, 308.800F, 313.850F, 308.250F, 312.600F, 298.830F};
 
 inline constexpr FrequencyBank BANKS[] = {
     {RX_EAST, TX_EAST, EAST_BANK_SIZE, "Восточный банк: основной набор частот восточного сегмента"},


### PR DESCRIPTION
## Summary
- correct the TX frequency associated with the 256.450 MHz RX channel in the home bank so it matches the reference table

## Testing
- pio check *(fails: command not found)*
- python - <<'PY' ... *(verifies RX/TX pairs for the home bank)*

------
https://chatgpt.com/codex/tasks/task_e_68e027b270088330ac831ede4359538b