### PR TITLE
Добавлено логирование и адаптация заголовков кадров

### DIFF
--- a/lib/frame/frame_header.h
+++ b/lib/frame/frame_header.h
@@ -12,7 +12,8 @@ struct FrameHeader {
   uint16_t frag_cnt = 1;    // общее число фрагментов
   uint32_t packed = 0;      // упакованные флаги, номер фрагмента и длина
 
-  static constexpr size_t SIZE = 12; // размер заголовка в байтах
+  static constexpr size_t SIZE = 12;     // размер стандартного заголовка в байтах
+  static constexpr size_t MIN_SIZE = 9;  // минимальный размер укороченного заголовка (без выравнивания)
   static constexpr uint32_t FLAGS_SHIFT = 24;      // старшие биты под флаги
   static constexpr uint32_t FLAGS_MASK = 0xFF000000; // маска флагов (8 бит)
   static constexpr uint32_t FRAG_SHIFT = 12;       // средние биты под индекс фрагмента (12 бит)


### PR DESCRIPTION
## Summary
- добавлен минимальный размер заголовка и расширенное логирование в FrameHeader::decode для диагностики несоответствий
- улучшена обработка укороченных или дублированных заголовков в RxModule с подробными предупреждениями и фиксацией смещений payload

## Testing
- make -C tests *(fails: отсутствует зависимость libsodium для сборки тестов)*

------
https://chatgpt.com/codex/tasks/task_e_68e141c5b47483308d980fe5f00cef53