### PR TITLE
Add missing FrameHeader MIN_SIZE constant

### DIFF
--- a/src/libs/frame/frame_header.h
+++ b/src/libs/frame/frame_header.h
@@ -12,7 +12,8 @@ struct FrameHeader {
   uint16_t frag_cnt = 1;    // общее число фрагментов
   uint32_t packed = 0;      // упакованные флаги, номер фрагмента и длина
 
-  static constexpr size_t SIZE = 12; // размер заголовка в байтах
+  static constexpr size_t SIZE = 12;     // размер стандартного заголовка в байтах
+  static constexpr size_t MIN_SIZE = 9;  // минимальный размер укороченного заголовка (без выравнивания)
   static constexpr uint32_t FLAGS_SHIFT = 24;      // старшие биты под флаги
   static constexpr uint32_t FLAGS_MASK = 0xFF000000; // маска флагов (8 бит)
   static constexpr uint32_t FRAG_SHIFT = 12;       // средние биты под индекс фрагмента (12 бит)


### PR DESCRIPTION
## Summary
- add the MIN_SIZE constant to the FrameHeader definition used by the RX module so the build can reference it
- clarify the comment for the standard header size to match the extended description

## Testing
- pio run *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1850641648330969a5deba632c03d