### PR TITLE
Настройка DIO1 SX1262 для логирования ошибок заголовка

### DIFF
--- a/src/radio_sx1262.cpp
+++ b/src/radio_sx1262.cpp
@@ -454,6 +454,17 @@ int16_t RadioSX1262::resetToDefaults() {
     lastError_ = state;                             // сохраняем код ошибки инициализации
     return lastError_;                              // ошибка инициализации
   }
+  radio_.setDioIrqParams(                          // настраиваем выводы прерываний SX1262
+      RADIOLIB_SX126X_IRQ_RX_DONE |
+          RADIOLIB_SX126X_IRQ_HEADER_VALID |
+          RADIOLIB_SX126X_IRQ_HEADER_ERR |
+          RADIOLIB_SX126X_IRQ_CRC_ERR,
+      RADIOLIB_SX126X_IRQ_RX_DONE |
+          RADIOLIB_SX126X_IRQ_HEADER_VALID |
+          RADIOLIB_SX126X_IRQ_HEADER_ERR |
+          RADIOLIB_SX126X_IRQ_CRC_ERR,
+      RADIOLIB_SX126X_IRQ_NONE,
+      RADIOLIB_SX126X_IRQ_NONE);
   radio_.setDio1Action(onDio1Static);                     // колбэк приёма
   if (!setRxBoostedGainMode(cfg.radio.rxBoostedGain)) {   // применение усиления по умолчанию
     rxBoostedGainEnabled_ = false;                        // фиксируем фактическое состояние


### PR DESCRIPTION
## Summary
- включена генерация IRQ RX_DONE, HEADER_VALID, HEADER_ERR и CRC_ERR на выводе DIO1 при инициализации SX1262

## Testing
- `pio run -v` *(прервано: зависание при загрузке платформы espressif32 в среде CI)*

------
https://chatgpt.com/codex/tasks/task_e_68e213860874833094b9cd220d1fea99