### PR TITLE
Improve SX1262 IRQ logging and RX dump

### DIFF
--- a/tests/stubs/RadioLib.h
+++ b/tests/stubs/RadioLib.h
@@ -2,6 +2,9 @@
 // Заглушка RadioLib для модульных тестов, исключающая обращение к реальному железу
 #include <cstddef>
 #include <cstdint>
+#include <array>
+#include <algorithm>
+#include <cstring>
 
 // Константы статусов и флагов IRQ, используемые в прошивке
 #define RADIOLIB_ERR_NONE 0
@@ -21,6 +24,7 @@
 #define RADIOLIB_IRQ_TX_TIMEOUT 0x0200U
 #define RADIOLIB_SX126X_IRQ_CAD_DONE 0x0400U
 #define RADIOLIB_SX126X_IRQ_CAD_DETECTED 0x0800U
+#define RADIOLIB_SX126X_IRQ_LR_FHSS_HOP 0x1000U
 
 class Module {
 public:
@@ -32,9 +36,9 @@ class SX1262 {
 public:
   explicit SX1262(Module* module) : module_(module) {}
 
-  int16_t begin(float, float, int, int, uint8_t, int8_t, uint16_t, float, bool) {
+  int16_t begin(float, float, uint8_t, uint8_t, uint8_t, int8_t, uint16_t, float, bool) {
     (void)module_;
-    return RADIOLIB_ERR_NONE;
+    return beginState;
   }
 
   int16_t setFrequency(float freq) {
@@ -49,7 +53,15 @@ public:
     return transmitResult;
   }
   size_t getPacketLength(bool = true) { return testPacketLength; }
-  int16_t readData(uint8_t*, size_t) { return testReadState; }
+  int16_t readData(uint8_t* data, size_t len) {
+    if (testReadState == RADIOLIB_ERR_NONE && data) {
+      const size_t copyLen = std::min(len, testReadBufferSize);
+      if (copyLen > 0) {
+        std::memcpy(data, testReadBuffer.data(), copyLen);
+      }
+    }
+    return testReadState;
+  }
   float getSNR() const { return testSnr; }
   float getRSSI() const { return testRssi; }
   uint8_t randomByte() { return nextRandom++; }
@@ -57,6 +69,17 @@ public:
     ++startReceiveCalls;              // учитываем попытки запуска приёма
     return startReceiveState;
   }
+  int16_t setDio2AsRfSwitch(bool) { return setDio2AsRfSwitchState; }
+  int16_t setDioIrqParams(uint16_t, uint16_t, uint16_t = RADIOLIB_SX126X_IRQ_NONE,
+                          uint16_t = RADIOLIB_SX126X_IRQ_NONE) {
+    return setDioIrqParamsState;
+  }
+  int16_t setCRC(uint8_t, uint16_t = 0x1D0F, uint16_t = 0x1021, bool = true) {
+    return setCRCState;
+  }
+  int16_t invertIQ(bool) { return invertIqState; }
+  int16_t implicitHeader(size_t) { return implicitHeaderState; }
+  int16_t explicitHeader() { return explicitHeaderState; }
   int16_t reset() { return RADIOLIB_ERR_NONE; }
   int16_t setBandwidth(float) { return RADIOLIB_ERR_NONE; }
   int16_t setSpreadingFactor(int) { return RADIOLIB_ERR_NONE; }
@@ -85,10 +108,19 @@ public:
   int16_t transmitResult = RADIOLIB_ERR_NONE; // код возврата transmit()
   int16_t setFrequencyState = RADIOLIB_ERR_NONE; // код возврата setFrequency()
   int16_t startReceiveState = RADIOLIB_ERR_NONE; // код возврата startReceive()
+  int16_t beginState = RADIOLIB_ERR_NONE;        // код возврата begin()
+  int16_t setDio2AsRfSwitchState = RADIOLIB_ERR_NONE; // код возврата setDio2AsRfSwitch()
+  int16_t setDioIrqParamsState = RADIOLIB_ERR_NONE;   // код возврата setDioIrqParams()
+  int16_t setCRCState = RADIOLIB_ERR_NONE;            // код возврата setCRC()
+  int16_t invertIqState = RADIOLIB_ERR_NONE;          // код возврата invertIQ()
+  int16_t implicitHeaderState = RADIOLIB_ERR_NONE;    // код возврата implicitHeader()
+  int16_t explicitHeaderState = RADIOLIB_ERR_NONE;    // код возврата explicitHeader()
   uint32_t testIrqFlags = 0;
   int16_t testClearIrqState = RADIOLIB_ERR_NONE;
   size_t testPacketLength = 0;
   int16_t testReadState = RADIOLIB_ERR_NONE;
+  std::array<uint8_t, 256> testReadBuffer{};
+  size_t testReadBufferSize = 0;
   float testSnr = 0.0f;
   float testRssi = 0.0f;
   uint8_t nextRandom = 0;


### PR DESCRIPTION
## Summary
- ensure the SX1262 IRQ log covers the LR-FHSS hop flag and shorten descriptions to stay within the logger limits
- add a debug hex dump of every received packet to simplify diagnostics
- extend the RadioLib stub and unit test to exercise the new logging behaviour

## Testing
- make -C tests build/test_radio_irq_logging SUPPORT_SRCS="../src/radio_sx1262.cpp ../src/logger.cpp ../src/libs/log_hook/log_hook.cpp ../src/libs/config_loader/config_loader.cpp" LDLIBS="" LDFLAGS=""
- ./tests/build/test_radio_irq_logging


------
https://chatgpt.com/codex/tasks/task_e_68e3da44a670833080d419c1791449c3