### PR TITLE
Исправить отображение пересланных сообщений

### DIFF
--- a/src/web/script.js
+++ b/src/web/script.js
@@ -1807,7 +1807,11 @@ function addChatMessage(entry, index, options) {
 }
 function setBubbleText(node, text) {
   const value = text == null ? "" : String(text);
-  const parts = value.split(/\r?\n/);
+  const normalized = value
+    .replace(/\r\n/g, "\n")                     // приводим CRLF к единым переводам строк
+    .replace(/\r/g, "\n")                        // одиночные CR тоже превращаем в LF
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, " "); // управляющие символы заменяем пробелом
+  const parts = normalized.split("\n");
   node.innerHTML = "";
   for (let i = 0; i < parts.length; i++) {
     if (i > 0) node.appendChild(document.createElement("br"));


### PR DESCRIPTION
## Summary
- нормализовал текст пузырей чата: перевод CR/CRLF в LF и замена управляющих символов пробелами, чтобы пересланные сообщения не обрезались

## Testing
- node <<'NODE'
const sanitize = (text) => {
  const value = text == null ? "" : String(text);
  const normalized = value
    .replace(/\r\n/g, "\n")
    .replace(/\r/g, "\n")
    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, " ");
  return normalized.split("\n");
};
console.log(sanitize("start\rmiddle\nend\u0007test"));
NODE

------
https://chatgpt.com/codex/tasks/task_e_68e5587e139c83308e2be08d3ca431b7