### PR TITLE
Улучшение парсинга параметров радиомодуля в Lotest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1194,6 +1194,7 @@ rs255223::decode -> PacketGatherer -> обработка сообщения
 - `onRadioDio1Rise()` — обработчик прерывания DIO1, переводящий приём в асинхронный режим.
 - `addEvent()` / `appendEventBuffer()` — формирование сообщений веб-чата и ограничение истории событий.
 - `handleRoot()`, `handleLog()`, `handleChannelChange()`, `handlePowerToggle()`, `handleSpreadingFactorToggle()`, `handleBandwidthChange()`, `handleCodingRateChange()`, `handleSendLongPacket()`, `handleSendRandomPacket()`, `handleSendCustom()`, `handleNotFound()` — обработчики HTTP-маршрутов веб-интерфейса.
+- `tryParseBandwidth()` и `tryParseCodingRate()` — нормализация пользовательских значений полосы/CR из HTTP-запросов (поддержка чисел с точкой/запятой, суффиксов `Hz`/`kHz`, записи в герцах и форматов `4/5`, `45`, `CR4/6`), чтобы радиопараметры надёжно применялись даже при нестандартном вводе.
 - `buildIndexHtml()` / `buildChannelOptions()` — генерация основной HTML-страницы и выпадающего списка каналов.
 - JavaScript-хелперы веб-интерфейса `encodeForm()`, `postForm()`, `refreshLog()`, `handleError()` и `sendCustom()` реализованы в 
   максимально совместимом стиле без `fetch`, `async/await`, `let/const` и стрелочных функций, чтобы страница корректно работала


### PR DESCRIPTION
## Summary
- добавил вспомогательные функции `tryParseBandwidth` и `tryParseCodingRate`, принимающие значения с различными форматами записи
- обновил обработчики `/api/bw` и `/api/cr`, чтобы использовать унифицированный парсинг и корректно применять параметры радиомодуля
- задокументировал новые функции Lotest в README

## Testing
- ⚠️ `pio run -d testing/fimrare -e lotest` (невозможно выполнить: команда `pio` недоступна в окружении)


------
https://chatgpt.com/codex/tasks/task_e_68e6409278508330b2df5c9e45493d19