### PR TITLE
Align lotest BW/CR configuration with main firmware

### DIFF
--- a/testing/fimrare/src/libs/radio/lora_radiolib_settings.h
+++ b/testing/fimrare/src/libs/radio/lora_radiolib_settings.h
@@ -11,7 +11,7 @@ struct SX1262DriverOptions {
                                       // Меньшая полоса повышает чувствительность и увеличивает время передачи.
   uint8_t spreadingFactor = 7;        // Фактор расширения SF (5..12).
                                       // Увеличение повышает устойчивость, но снижает скорость.
-  uint8_t codingRateDenom = 8;        // Делитель коэффициента кодирования CR (5..8).
+  uint8_t codingRateDenom = 5;        // Делитель коэффициента кодирования CR (5..8).
                                       // CR=4/denom, задаёт избыточность и помехоустойчивость.
   int8_t lowPowerDbm = -5;            // Низкий уровень мощности передачи (dBm) для щадящего режима.
   int8_t highPowerDbm = 22;           // Высокий уровень мощности передачи (dBm) для максимальной дальности.
@@ -22,7 +22,7 @@ struct SX1262DriverOptions {
   bool enableRegulatorDCDC = false;   // Принудительный перевод радиочасти в режим DC-DC (если поддерживается аппаратно).
   bool autoLdro = true;               // Автоматический выбор оптимизации для низких скоростей передачи (LDRO).
   bool implicitHeader = true;         // Использовать фиксированный размер пакета (implicit header) вместо стандартного заголовка.
-  uint8_t implicitPayloadLength = 8;  // Размер полезной нагрузки при implicit header (байты).
+  uint8_t implicitPayloadLength = 32; // Размер полезной нагрузки при implicit header (байты).
   bool enableCrc = false;              // Добавлять ли аппаратный CRC в конец LoRa-пакета.
   bool invertIq = false;              // Инверсия фаз (I/Q) для совместимости с определёнными сетями.
   bool publicNetwork = true;          // Использовать стандартное публичное синхрослово LoRa (true) либо приватное (false).

--- a/testing/fimrare/src/main.cpp
+++ b/testing/fimrare/src/main.cpp
@@ -27,8 +27,8 @@ constexpr uint8_t kDefaultSpreadingFactor = kRadioDefaults.spreadingFactor; // �
 constexpr uint8_t kDefaultCodingRate = kRadioDefaults.codingRateDenom;      // делитель коэффициента кодирования CR
 constexpr int8_t kLowPowerDbm = kRadioDefaults.lowPowerDbm;                 // низкий уровень мощности
 constexpr int8_t kHighPowerDbm = kRadioDefaults.highPowerDbm;               // высокий уровень мощности
-constexpr std::array<float, 10> kSupportedBandwidths = {
-    7.81f, 10.42f, 15.63f, 20.83f, 31.25f, 41.67f, 62.50f, 125.00f, 250.00f, 500.00f}; // допустимые полосы (кГц)
+constexpr std::array<float, 5> kSupportedBandwidths = {
+    7.81f, 10.42f, 15.63f, 20.83f, 31.25f}; // допустимые полосы (кГц), как в основной прошивке
 constexpr std::array<uint8_t, 4> kSupportedCodingRates = {5, 6, 7, 8};       // допустимые делители CR
 constexpr float kBandwidthTolerance = 0.02f;                                 // допуск сравнения полосы в кГц
 } // namespace


### PR DESCRIPTION
## Summary
- обновил дефолтные параметры LoRa в lotest, чтобы использовать коэффициент кодирования 4/5 и 32-байтовый implicit-пакет как в основной прошивке
- ограничил список доступных полос пропускания в lotest теми же значениями, что поддерживаются основной прошивкой

## Testing
- `pio run -e lotest` *(неуспешно: в окружении отсутствует PlatformIO CLI)*

------
https://chatgpt.com/codex/tasks/task_e_68e64dd1e1a48330936ec1ad77662cb2