### PR TITLE
Handle SX1262 transmit timeout false positives

### DIFF
--- a/tests/stubs/RadioLib.h
+++ b/tests/stubs/RadioLib.h
@@ -8,6 +8,7 @@
 
 // Константы статусов и флагов IRQ, используемые в прошивке
 #define RADIOLIB_ERR_NONE 0
+#define RADIOLIB_ERR_TX_TIMEOUT -5
 #define RADIOLIB_ERR_CHANNEL_BUSY -16
 #define RADIOLIB_ERR_CHANNEL_BUSY_LBT -17
 #define RADIOLIB_SX126X_IRQ_NONE 0x0000U
@@ -88,7 +89,10 @@ public:
   int16_t setRxBoostedGainMode(bool, bool) { return RADIOLIB_ERR_NONE; }
   void setDio1Action(void (*)(void)) {}
   uint32_t getIrqFlags() { return testIrqFlags; }
-  int16_t clearIrqFlags(uint32_t) { return testClearIrqState; }
+  int16_t clearIrqFlags(uint32_t mask) {
+    testIrqFlags &= ~mask;
+    return testClearIrqState;
+  }
   uint16_t getIrqStatus() { return static_cast<uint16_t>(testIrqFlags); }
   int16_t getIrqStatus(uint16_t* dest) {
     if (dest) {


### PR DESCRIPTION
## Summary
- treat RadioLib TX timeout as a successful transmission when the SX1262 reports TX_DONE, avoiding spurious errors on some boards
- clear the pending TX_DONE flag and log the recovery so future sends are not blocked
- update the RadioLib stub and radio send recovery test to cover the timeout recovery path

## Testing
- make -C tests test_radio_send_error_recovery *(fails: libsodium headers are not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6627f34a0833091febaa3e5a5d800