### PR TITLE
Fix: очистка конфликтных маркеров в radio_sx1262

### DIFF
--- a/src/radio_sx1262.h
+++ b/src/radio_sx1262.h
@@ -75,7 +75,6 @@ int16_t CallPointerGetIrqStatus(Radio&, uint16_t*, long) {
   return RADIOLIB_ERR_NONE;
 }
 
-<<<<<<< ours
 // Универсальное чтение флагов IRQ с учётом доступного варианта API
 template <typename Radio>
 uint32_t ReadIrqFlags(Radio& radio) {
@@ -103,8 +102,6 @@ int16_t ClearIrqFlags(Radio& radio, uint32_t mask) {
   }
 }
 
-=======
->>>>>>> theirs
 } // namespace radio_sx1262_detail
 
 // Реализация радиоинтерфейса на базе SX1262
@@ -201,38 +198,12 @@ private:
 
     // Универсальный доступ к флагам IRQ с учётом варианта API библиотеки
     uint32_t getIrqFlags() {
-<<<<<<< ours
       return radio_sx1262_detail::ReadIrqFlags(static_cast<SX1262&>(*this));
-=======
-      if constexpr (radio_sx1262_detail::HasIrqFlagsApi<SX1262>::value) {
-        return SX1262::getIrqFlags();
-      } else if constexpr (radio_sx1262_detail::HasZeroArgIrqStatusApi<SX1262>::value) {
-        return static_cast<uint32_t>(
-            radio_sx1262_detail::CallZeroArgGetIrqStatus(
-                static_cast<SX1262&>(*this), 0));
-      } else if constexpr (radio_sx1262_detail::HasPointerIrqStatusApi<SX1262>::value) {
-        uint16_t legacyFlags = 0;
-        int16_t state = radio_sx1262_detail::CallPointerGetIrqStatus(
-            static_cast<SX1262&>(*this), &legacyFlags, 0);
-        return (state == RADIOLIB_ERR_NONE) ? legacyFlags : 0U;
-      } else {
-        return 0U;
-      }
->>>>>>> theirs
     }
 
     // Очистка флагов IRQ через доступный механизм
     int16_t clearIrqFlags(uint32_t mask) {
-<<<<<<< ours
       return radio_sx1262_detail::ClearIrqFlags(static_cast<SX1262&>(*this), mask);
-=======
-      if constexpr (radio_sx1262_detail::HasIrqFlagsApi<SX1262>::value) {
-        return SX1262::clearIrqFlags(mask);
-      } else {
-        (void)mask;
-        return this->clearIrqStatus();
-      }
->>>>>>> theirs
     }
 
     // Совместимость с API, ожидающим возвращение статуса без аргументов


### PR DESCRIPTION
## Summary
- удалены остаточные маркеры слияния в `src/radio_sx1262.h`
- выровнено использование универсальных хелперов чтения и очистки IRQ для совместимости с различными версиями API RadioLib

## Testing
- `cd tests && make -j4`
- `cd tests && for f in build/test_*; do "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_68e6c22472d483308c02465db5a8dd7f